### PR TITLE
fix(WT): prefer number than WT

### DIFF
--- a/gdcdictionary/schemas/experimental_analysis.yaml
+++ b/gdcdictionary/schemas/experimental_analysis.yaml
@@ -61,8 +61,8 @@ properties:
       The lower limit of detection. lowest quantity of a substance that can be distinguished from
       the absence of that substance (a blank value) within a stated confidence limit (generally 1%).
     type:
-      - string
       - number
+      - string
     oneOf:
       - enum: ['WT']
       - type: number
@@ -70,16 +70,16 @@ properties:
   specificity:
     description: "The true negative rate."
     type:
-      - string
       - number
+      - string
     oneOf:
       - enum: ['WT']
       - type: number
   sensitivity:
     description: "The true positive rate."
     type:
-      - string
       - number
+      - string
     oneOf:
       - enum: ['WT']
       - type: number


### PR DESCRIPTION
so... when a `llod` is represented in tsv, the tsv2json converter try to cast it to the expected type, it just try in the `type` list from first to last until it succeeds.
If it trieds `string` first, `1.0` will succeed. So it produced a json 
```
{
  'type': 'experimental_analysis',
  'llod': '1.0'
}
```
then api goes to validation part, found `'1.0' != 'WT' and type('1.0') != float`, then it tells user that your data doesn't match our schema.
So I reversed the order so that it prefers to cast value to number.
This will also be a thing you need to know about if you support this kind of type in gdc.
r? @dmiller15  