### PR TITLE
Allow multiple references prepended with $ref

### DIFF
--- a/gdcdictionary/python/__init__.py
+++ b/gdcdictionary/python/__init__.py
@@ -129,12 +129,12 @@ class GDCDictionary(object):
         :returns: A denormalized/resolved version of :param:`obj`.
 
         """
-
+        refkey = '$ref'
         if isinstance(obj, dict):
-            for key in obj.keys():
-                if key == '$ref':
-                    val = obj.pop(key)
-                    obj.update(self.resolve_reference(val, root))
+            all_refkeys = [k for k in obj.keys() if k.startswith(refkey)]
+            for key in all_refkeys:
+                val = obj.pop(key)
+                obj.update(self.resolve_reference(val, root))
             return {k: self.resolve_schema(v, root) for k, v in obj.items()}
         elif isinstance(obj, list):
             return [self.resolve_schema(item, root) for item in obj]

--- a/gdcdictionary/schema_test.py
+++ b/gdcdictionary/schema_test.py
@@ -104,7 +104,7 @@ class SchemaTest(unittest.TestCase):
 
     def test_valid_files(self):
         for path in glob.glob(os.path.join(DATA_DIR, 'valid', '*.json')):
-            print "Validating {}".format(path)
+            print("Validating {}".format(path))
             doc = json.load(open(path, 'r'))
             print(doc)
             if type(doc) == dict:
@@ -119,7 +119,7 @@ class SchemaTest(unittest.TestCase):
 
     def test_invalid_files(self):
         for path in glob.glob(os.path.join(DATA_DIR, 'invalid', '*.json')):
-            print "Validating {}".format(path)
+            print("Validating {}".format(path))
             doc = json.load(open(path, 'r'))
             if type(doc) == dict:
                 self.add_system_props(doc)
@@ -173,7 +173,7 @@ if __name__ == '__main__':
         if args.invalid:
             try:
                 print("CHECK if {0} is invalid:".format(f.name)),
-                print type(doc)
+                print(type(doc))
                 if type(doc) == dict:
                     validate_entity(doc, dictionary.schema)
                 elif type(doc) == list:
@@ -194,7 +194,7 @@ if __name__ == '__main__':
                 for entity in doc:
                     validate_entity(entity, dictionary.schema)
             else:
-                print "Invalid json"
+                print("Invalid json")
 
             print("Valid as expected")
     print('ok.')


### PR DESCRIPTION
Figured the BPA dictionary might be the best entry point for this if interested:

Should allow for schemas like:
```yaml
properties:
  $ref_ubiq: "_definitions.yaml#/ubiquitous_properties"
  $ref_bio: "_definitions.yaml#/biospecimen_properties"
```
Note: this is not canonical JSON schema, but the resolved
schema should be valid JSON schema that can be consumed by
other tools.

Rider: add parens to all print statements

r? @philloooo @dmiller15 