### PR TITLE
feat(index): required index_date

### DIFF
--- a/gdcdictionary/examples/valid/biospecimen.json
+++ b/gdcdictionary/examples/valid/biospecimen.json
@@ -3,7 +3,7 @@
     "submitter_id":"blood draw 1",
     "clinical_site": "C1",
     "days_to_collection":26,
-    "days_to_procurement":25,
+    "days_to_procurement":-1,
     "blood_draw_method":"BloodDrawProtocol.pdf",
     "method_of_procurement":"Blood Draw",
     "biospecimen_type":"Fluid",

--- a/gdcdictionary/schemas/biospecimen.yaml
+++ b/gdcdictionary/schemas/biospecimen.yaml
@@ -369,12 +369,31 @@ properties:
       in all projects.
     type: string
   days_to_collection:
-    term:
-      $ref: "_terms.yaml#/days_to_collection"
-    type: integer
+    description: >
+      The number of days between the index date and the date the biospecimen was collected at the
+      laboratory. Use Unknown if the date of the event is not known. Use Not Applicable if the event
+      never happened.
+    type:
+      - number
+      - string
+    oneOf:
+      - enum:
+          - Not Applicable
+          - Unknown
+      - type: integer
   days_to_procurement:
-    description: "The number of days between the index date and the date the biospecimen was taken from the patient (such as the blood draw)."
-    type: integer
+    description: >
+      The number of days between the index date and the date the biospecimen was taken from the
+      patient (such as the blood draw). Use Unknown if the date of the event is not known. Use Not
+      Applicable if the event never happened."
+    type:
+      - number
+      - string
+    oneOf:
+      - enum:
+          - Not Applicable
+          - Unknown
+      - type: integer 
   disease_type:
     description: "The primary disease of the patient from which the biospecimen was taken."
     enum:

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -30,6 +30,7 @@ links:
 
 required:
   - submitter_id
+  - index_date
   - studies
 
 uniqueKeys:


### PR DESCRIPTION
added NA option to index_date
added NA/Unknown options for days_to_procurement/collection

r?

This is a breaking change. We already created the AB state with #50; once we complete a migration, we can merge this change to finish the migration to the B state.