### PR TITLE
feat(protocol): require link to study

### DIFF
--- a/gdcdictionary/schemas/protocol.yaml
+++ b/gdcdictionary/schemas/protocol.yaml
@@ -29,7 +29,7 @@ links:
     label: derived_from
     target_type: study
     multiplicity: many_to_many
-    required: false
+    required: true 
 
 required:
   - submitter_id


### PR DESCRIPTION
r?

This is a breaking change. The current state is the AB state so we don't need to create one. Once all existing protocol nodes are linked to a study, we can merge and deploy this to finish the transition to the B state.