### PR TITLE
added age restrictions for PHI

### DIFF
--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -31,7 +31,17 @@ adapter_sequence: # TOREVIEW
 
 age_at_diagnosis:
   description: >
-    Age at the time of diagnosis expressed in number of days since birth.
+    Age at the time of diagnosis expressed in number of days since birth. If the age at diagnosis is greater than 32872 days (89 years), then see 'age_at_diagnosis_gt89'.
+  termDef:
+    term: Patient Diagnosis Age Day Value
+    source: caDSR
+    cde_id: 3225640
+    cde_version: 2.0
+    term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3225640&version=2.0"
+
+age_at_diagnosis_gt89:
+  description: >
+    Indicate if the age at the time of diagnosis expressed in number of days since birth is greater than 32872 days (89 years).
   termDef:
     term: Patient Diagnosis Age Day Value
     source: caDSR
@@ -1382,7 +1392,17 @@ read_group_name: # TOREVIEW
 
 relationship_age_at_diagnosis:
   description: >
-    The age (in years) when the patient's relative was first diagnosed.
+    The age (in years) when the patient's relative was first diagnosed; if age is greater than 89 years, use 'relationship_age_at_diagnosis_gt89'.
+  termDef:
+    term: Relative Diagnosis Age Value
+    source: caDSR
+    cde_id: 5300571
+    cde_version: 1.0
+    term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5300571&version=1.0"
+
+relationship_age_at_diagnosis_gt89:
+  description: >
+    Indicate whether the age (in years) when the patient's relative was first diagnosed is greater than 89 years.
   termDef:
     term: Relative Diagnosis Age Value
     source: caDSR

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -3,7 +3,7 @@ $schema: "http://json-schema.org/draft-04/schema#"
 id: "demographic"
 title: Demographic
 type: object
-namespace: https://www.bloodpac.org 
+namespace: https://www.bloodpac.org
 category: clinical
 program: '*'
 project: '*'
@@ -42,51 +42,69 @@ properties:
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
   cause_of_death:
-    description: "Text term to identify the cause of patient death with respect to cancer."
+    description: >
+      Text term to identify the cause of patient death with respect to cancer.
     enum:
-      - Cancer Related
-      - Not Cancer Related
-      - Unknown
+      - "Cancer Related"
+      - "Not Cancer Related"
+      - "Unknown"
+
   days_to_birth:
-    description: "The number of days between the index date and the date of patient birth." 
+    description: >
+      The number of days between the index date and the date of patient birth. If the number of days is greater than 32872 (89 years), then please use 'days_to_birth_gt89'.
     type: integer
+    maximum: 32872
+    minimum: 0
+
+  days_to_birth_gt89:
+    description: >
+      Indicate if the number of days between the index date and the date of patient birth is greater than 32872 (89 years).
+    enum:
+      - "Yes"
+      - "No"
+
   days_to_death:
-    description: "The number of days between the index date and the date of patient death." 
-    type: integer 
+    description: >
+      The number of days between the index date and the date of patient death.
+    type: integer
+
   ethnicity:
     term:
       $ref: "_terms.yaml#/ethnicity"
     enum:
-      - Hispanic or Latino
-      - Not Hispanic or Latino
-      - Unknown
+      - "Hispanic or Latino"
+      - "Not Hispanic or Latino"
+      - "Unknown"
+
   gender:
     term:
       $ref: "_terms.yaml#/gender"
     enum:
-      - Female
-      - Male
-      - Unknown
-      - Unspecified
+      - "Female"
+      - "Male"
+      - "Unknown"
+      - "Unspecified"
+
   race:
     term:
       $ref: "_terms.yaml#/race"
     enum:
-      - White
-      - American Indian or Alaska Native
-      - Black or African American
-      - Asian
-      - Native Hawaiian or Other Pacific Islander
-      - Other
-      - Unknown
+      - "White"
+      - "American Indian or Alaska Native"
+      - "Black or African American"
+      - "Asian"
+      - "Native Hawaiian or Other Pacific Islander"
+      - "Other"
+      - "Unknown"
+
   vital_status:
     term:
       $ref: "_terms.yaml#/vital_status"
     enum:
-      - Alive
-      - Dead
-      - Lost to Follow-up
-      - Unknown
+      - "Alive"
+      - "Dead"
+      - "Lost to Follow-up"
+      - "Unknown"
 
   cases:
     $ref: "_definitions.yaml#/to_one"

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -46,6 +46,20 @@ uniqueKeys:
 properties:
   $ref: "_definitions.yaml#/ubiquitous_properties"
 
+  age_at_diagnosis:
+    term:
+      $ref: "_terms.yaml#/age_at_diagnosis"
+    type: integer
+    maximum: 32872
+    minimum: 0
+
+  age_at_diagnosis_gt89:
+    term:
+      $ref: "_terms.yaml#/age_at_diagnosis_gt89"
+    enum:
+      - "Yes"
+      - "No"
+
   ajcc_clinical_m:
     term:
       $ref: "_terms.yaml#/ajcc_clinical_m"
@@ -1428,13 +1442,13 @@ properties:
   primary_diagnosis:
     term:
       $ref: "_terms.yaml#/primary_diagnosis"
-    enum: 
+    enum:
       - Abdominal desmoid
       - Abdominal fibromatosis
-      - Achromic nevus 
-      - Acidophil adenocarcinoma 
-      - Acidophil adenoma 
-      - Acidophil carcinoma 
+      - Achromic nevus
+      - Acidophil adenocarcinoma
+      - Acidophil adenoma
+      - Acidophil carcinoma
       - Acinar adenocarcinoma
       - Acinar adenoma
       - Acinar carcinoma
@@ -1445,9 +1459,9 @@ properties:
       - Acinic cell adenocarcinoma
       - Acinic cell adenoma
       - Acinic cell tumor [obs]
-      - Acoustic neuroma 
+      - Acoustic neuroma
       - Acquired tufted hemangioma
-      - Acral lentiginous melanoma, malignant 
+      - Acral lentiginous melanoma, malignant
       - ACTH-producing tumor
       - Acute basophilic leukaemia
       - Acute bilineal leukemia
@@ -1462,7 +1476,7 @@ properties:
       - Acute lymphoblastic leukemia-lymphoma, NOS
       - Acute lymphoblastic leukemia, L2 type, NOS
       - Acute lymphoblastic leukemia, mature B-cell type
-      - Acute lymphoblastic leukemia, NOS 
+      - Acute lymphoblastic leukemia, NOS
       - Acute lymphoblastic leukemia, precursorcell type
       - Acute lymphocytic leukemia
       - Acute lymphoid leukemia
@@ -1505,13 +1519,13 @@ properties:
       - Acute myloid leukemia, 11q23 abnormalities
       - Acute myloid leukemia, MLL
       - Acute non-lymphocytic leukemia
-      - Acute panmyelosis with myelofibrosis 
+      - Acute panmyelosis with myelofibrosis
       - Acute panmyelosis, NOS
-      - Acute progressive histiocytosis X 
+      - Acute progressive histiocytosis X
       - Acute promyelocytic leukaemia, PML-RAR-alpha
       - Acute promyelocytic leukaemia, t(15;17) (q22;q11-12)
       - Acute promyelocytic leukemia, NOS
-      - Adamantinoma of long bones 
+      - Adamantinoma of long bones
       - Adamantinoma, malignant (except of long bones)
       - Adamantinoma, NOS (except of long bones)
       - Adenoacanthoma
@@ -1520,7 +1534,7 @@ properties:
       - Adenocarcinoma combined with other types of carcinoma
       - Adenocarcinoma in a polyp, NOS
       - Adenocarcinoma in adenomatous polyp
-      - Adenocarcinoma in adenomatous polyposis coli 
+      - Adenocarcinoma in adenomatous polyposis coli
       - Adenocarcinoma in multiple adenomatous polyps
       - Adenocarcinoma in polypoid adenoma
       - Adenocarcinoma in situ in a polyp, NOS
@@ -1533,8 +1547,8 @@ properties:
       - Adenocarcinoma in tubolovillous adenoma
       - Adenocarcinoma in tubular adenoma
       - Adenocarcinoma in villous adenoma
-      - Adenocarcinoma of anal ducts 
-      - Adenocarcinoma of anal glands 
+      - Adenocarcinoma of anal ducts
+      - Adenocarcinoma of anal glands
       - Adenocarcinoma with apocrine metaplasia
       - Adenocarcinoma with cartilaginous and osseous metaplasia
       - Adenocarcinoma with cartilaginous metaplasia
@@ -1543,46 +1557,46 @@ properties:
       - Adenocarcinoma with osseous metaplasia
       - Adenocarcinoma with spindle cell metaplasia
       - Adenocarcinoma with squamous metaplasia
-      - Adenocarcinoma, cribriform comedo-type 
+      - Adenocarcinoma, cribriform comedo-type
       - Adenocarcinoma, cylindroid
-      - Adenocarcinoma, diffuse type 
+      - Adenocarcinoma, diffuse type
       - Adenocarcinoma, endocervical type
-      - Adenocarcinoma, intestinal type 
+      - Adenocarcinoma, intestinal type
       - Adenocarcinoma, metastatic, NOS
       - Adenocarcinoma, NOS
-      - Adenocarcinoma, pancreatobiliary type 
+      - Adenocarcinoma, pancreatobiliary type
       - Adenocystic carcinoma
       - Adenofibroma, NOS
-      - Adenoid basal carcinoma 
+      - Adenoid basal carcinoma
       - Adenoid cystic carcinoma
       - Adenolipoma
-      - Adenolymphoma 
-      - Adenoma of nipple 
+      - Adenolymphoma
+      - Adenoma of nipple
       - Adenoma, NOS
       - Adenomatoid odontogenic tumor
       - Adenomatoid tumor, NOS
       - Adenomatosis, NOS
       - Adenomatous polyp, NOS
-      - Adenomatous polyposis coli 
-      - Adenomyoepithelioma 
+      - Adenomatous polyposis coli
+      - Adenomyoepithelioma
       - Adenomyoma
       - Adenosarcoma
       - Adenosquamous carcinoma
-      - Adnexal carcinoma 
-      - Adnexal tumor, benign 
-      - Adrenal cortical adenocarcinoma 
-      - Adrenal cortical adenoma, clear cell 
-      - Adrenal cortical adenoma, compact cell 
-      - Adrenal cortical adenoma, glomerulosa cell 
-      - Adrenal cortical adenoma, mixed cell 
-      - Adrenal cortical adenoma, NOS 
-      - Adrenal cortical adenoma, pigmented 
-      - Adrenal cortical carcinoma 
-      - Adrenal cortical tumor, benign 
-      - Adrenal cortical tumor, malignant 
-      - Adrenal cortical tumor, NOS 
-      - Adrenal medullary paraganglioma 
-      - Adrenal medullary paraganglioma, malignant 
+      - Adnexal carcinoma
+      - Adnexal tumor, benign
+      - Adrenal cortical adenocarcinoma
+      - Adrenal cortical adenoma, clear cell
+      - Adrenal cortical adenoma, compact cell
+      - Adrenal cortical adenoma, glomerulosa cell
+      - Adrenal cortical adenoma, mixed cell
+      - Adrenal cortical adenoma, NOS
+      - Adrenal cortical adenoma, pigmented
+      - Adrenal cortical carcinoma
+      - Adrenal cortical tumor, benign
+      - Adrenal cortical tumor, malignant
+      - Adrenal cortical tumor, NOS
+      - Adrenal medullary paraganglioma
+      - Adrenal medullary paraganglioma, malignant
       - Adrenal rest tumor
       - Adult cystic teratoma
       - Adult rhabdomyoma
@@ -1592,13 +1606,13 @@ properties:
       - Adult T-cell lymphoma/leukemia
       - Adult teratoma, NOS
       - Aggressive angiomyxoma
-      - Aggressive digital papillary adenoma 
+      - Aggressive digital papillary adenoma
       - Aggressive fibromatosis
       - Aggressive NK-cell leukaemia
-      - Aggressive osteoblastoma 
+      - Aggressive osteoblastoma
       - Aggressive systemic mastocytosis
       - Agnogenic myeloid metaplasia
-      - AIN III 
+      - AIN III
       - Aleukemic granulocytic leukemia [obs]
       - Aleukemic leukemia, NOS [obs]
       - Aleukemic lymphatic leukemia [obs]
@@ -1608,16 +1622,16 @@ properties:
       - Aleukemic myelogenous leukemia [obs]
       - Aleukemic myeloid leukemia [obs]
       - ALK positive large B-cell lymphoma
-      - Alpha cell tumor, malignant 
-      - Alpha cell tumor, NOS 
+      - Alpha cell tumor, malignant
+      - Alpha cell tumor, NOS
       - Alpha heavy chain disease
-      - Alveolar adenocarcinoma 
-      - Alveolar adenoma 
+      - Alveolar adenocarcinoma
+      - Alveolar adenoma
       - Alveolar carcinoma
-      - Alveolar cell carcinoma 
+      - Alveolar cell carcinoma
       - Alveolar rhabdomyosarcoma
       - Alveolar soft part sarcoma
-      - Amelanotic melanoma 
+      - Amelanotic melanoma
       - Ameloblastic carcinoma
       - Ameloblastic fibro-odontoma
       - Ameloblastic fibro-odontosarcoma
@@ -1630,8 +1644,8 @@ properties:
       - Ameloblastoma, malignant
       - Ameloblastoma, NOS
       - AML M6
-      - Anal intraepithelial neoplasia, grade III 
-      - Anal intraepithelial neoplasia, low grade 
+      - Anal intraepithelial neoplasia, grade III
+      - Anal intraepithelial neoplasia, low grade
       - Anaplastic large B-cell lymphoma
       - Anaplastic large cell lymphoma, ALK negative
       - Anaplastic large cell lymphoma, ALK positive
@@ -1639,7 +1653,7 @@ properties:
       - Anaplastic large cell lymphoma, NOS
       - Anaplastic large cell lymphoma, T cell and Null cell type
       - Anaplastic medulloblastoma
-      - Anaplastic oligoastrocytoma 
+      - Anaplastic oligoastrocytoma
       - Ancient schwannoma
       - Androblastoma, benign
       - Androblastoma, malignant
@@ -1668,9 +1682,9 @@ properties:
       - Angiomyxoma
       - Angiosarcoma
       - Angiotropic lymphoma
-      - Aortic body paraganglioma 
-      - Aortic body tumor 
-      - Aorticopulmonary paraganglioma 
+      - Aortic body paraganglioma
+      - Aortic body tumor
+      - Aorticopulmonary paraganglioma
       - Apocrine adenocarcinoma
       - Apocrine adenoma
       - Apocrine cystadenoma
@@ -1682,31 +1696,31 @@ properties:
       - Arrhenoblastoma, NOS
       - Arteriovenous hemangioma
       - Askin tumor
-      - Astroblastoma 
-      - Astrocytic glioma 
-      - Astrocytoma, anaplastic 
-      - Astrocytoma, low grade 
-      - Astrocytoma, NOS 
-      - Astroglioma 
+      - Astroblastoma
+      - Astrocytic glioma
+      - Astrocytoma, anaplastic
+      - Astrocytoma, low grade
+      - Astrocytoma, NOS
+      - Astroglioma
       - Atypical adenoma
       - Atypical carcinoid tumor
-      - Atypical choroid plexus papilloma 
+      - Atypical choroid plexus papilloma
       - Atypical chronic myeloid leukemia, BCR/ABL negative
       - Atypical chronic myeloid leukemia, Philadelphia chromosome (Ph1) negative
       - Atypical fibrous histiocytoma
       - Atypical fibroxanthoma
-      - Atypical follicular adenoma 
+      - Atypical follicular adenoma
       - Atypical leiomyoma
       - Atypical lipoma
-      - Atypical medullary carcinoma 
+      - Atypical medullary carcinoma
       - Atypical meningioma
       - Atypical polypoid adenomyoma
-      - Atypical proliferating clear cell tumor 
-      - Atypical proliferating serous tumor 
+      - Atypical proliferating clear cell tumor
+      - Atypical proliferating serous tumor
       - Atypical proliferative endometrioid tumor
-      - Atypical proliferative mucinous tumor 
-      - Atypical proliferative papillary serous tumor 
-      - Atypical teratoid/rhabdoid tumor 
+      - Atypical proliferative mucinous tumor
+      - Atypical proliferative papillary serous tumor
+      - Atypical teratoid/rhabdoid tumor
       - B cell lymphoma, NOS
       - B lymphoblastic leukemia/lymphoma with hyperdiploidy
       - B lymphoblastic leukemia/lymphoma with hypodiploidy (Hypodiploid ALL)
@@ -1717,85 +1731,85 @@ properties:
       - B lymphoblastic leukemia/lymphoma with t(v;11q23); MLL rearranged
       - B lymphoblastic leukemia/lymphoma, NOS
       - B-ALL [obs]
-      - B-cell lymphocytic leukemia/small lymphocytic lymphoma 
+      - B-cell lymphocytic leukemia/small lymphocytic lymphoma
       - B-cell lymphoma, unclassifiable, with features intermediate between diffuse large B-cell lymphoma and Burkitt lymphoma
       - B-cell lymphoma, unclassifiable, with features intermediate between diffuse large B-cell lymphoma and classical Hodgkin lymphoma
-      - Balloon cell melanoma 
-      - Balloon cell nevus 
+      - Balloon cell melanoma
+      - Balloon cell nevus
       - BALT lymphoma
       - Basal cell adenocarcinoma
       - Basal cell adenoma
-      - Basal cell carcinoma, desmoplastic type 
-      - Basal cell carcinoma, fibroepithelial 
-      - Basal cell carcinoma, micronodular 
-      - Basal cell carcinoma, morpheic 
-      - Basal cell carcinoma, nodular 
-      - Basal cell carcinoma, NOS 
-      - Basal cell epithelioma 
-      - Basal cell tumor 
+      - Basal cell carcinoma, desmoplastic type
+      - Basal cell carcinoma, fibroepithelial
+      - Basal cell carcinoma, micronodular
+      - Basal cell carcinoma, morpheic
+      - Basal cell carcinoma, nodular
+      - Basal cell carcinoma, NOS
+      - Basal cell epithelioma
+      - Basal cell tumor
       - Basaloid carcinoma
       - Basaloid squamous cell carcinoma
-      - Basophil adenocarcinoma 
-      - Basophil adenoma 
-      - Basophil carcinoma 
-      - Basosquamous carcinoma 
-      - Bednar tumor 
-      - Bellini duct carcinoma 
-      - Benign cystic nephroma 
+      - Basophil adenocarcinoma
+      - Basophil adenoma
+      - Basophil carcinoma
+      - Basosquamous carcinoma
+      - Bednar tumor
+      - Bellini duct carcinoma
+      - Benign cystic nephroma
       - Benign fibrous histiocytoma
-      - Beta cell adenoma 
-      - Beta cell tumor, malignant 
-      - Bile duct adenocarcinoma 
-      - Bile duct adenoma 
-      - Bile duct carcinoma 
-      - Bile duct cystadenocarcinoma 
-      - Bile duct cystadenoma 
+      - Beta cell adenoma
+      - Beta cell tumor, malignant
+      - Bile duct adenocarcinoma
+      - Bile duct adenoma
+      - Bile duct carcinoma
+      - Bile duct cystadenocarcinoma
+      - Bile duct cystadenoma
       - Biliary intraepithelial neoplasia, grade 3 (BilIN-3)
       - Biliary intraepithelial neoplasia, high grade
       - Biliary intraepithelial neoplasia, low grade
-      - Biliary papillomatosis 
+      - Biliary papillomatosis
       - Bizarre leiomyoma
-      - Black adenoma 
+      - Black adenoma
       - Blast cell leukemia
       - Blastic NK cell lymphoma [obs]
       - Blastic plasmacytoid dendritic cell neoplasm
       - Blastoma, NOS
-      - Blue nevus, malignant 
-      - Blue nevus, NOS 
+      - Blue nevus, malignant
+      - Blue nevus, NOS
       - Botryoid sarcoma
-      - Bowen disease 
-      - Brenner tumor, borderline malignancy 
-      - Brenner tumor, malignant 
-      - Brenner tumor, NOS 
-      - Brenner tumor, proliferating 
-      - Bronchial adenoma, carcinoid 
-      - Bronchial adenoma, cylindroid 
-      - Bronchial adenoma, NOS 
+      - Bowen disease
+      - Brenner tumor, borderline malignancy
+      - Brenner tumor, malignant
+      - Brenner tumor, NOS
+      - Brenner tumor, proliferating
+      - Bronchial adenoma, carcinoid
+      - Bronchial adenoma, cylindroid
+      - Bronchial adenoma, NOS
       - Bronchial-associated lymphoid tussue lymphoma
-      - Bronchio-alveolar carcinoma, mixed mucinous and non-mucinous 
-      - Bronchio-alveolar carcinoma, mucinous 
-      - Bronchiolar adenocarcinoma 
-      - Bronchiolar carcinoma 
-      - Bronchiolo-alveolar adenocarcinoma, NOS 
-      - Bronchiolo-alveolar carcinoma, Clara cell 
-      - Bronchiolo-alveolar carcinoma, Clara cell and goblet cell type 
-      - Bronchiolo-alveolar carcinoma, goblet cell type 
-      - Bronchiolo-alveolar carcinoma, indeterminate type 
-      - Bronchiolo-alveolar carcinoma, non-mucinous 
-      - Bronchiolo-alveolar carcinoma, NOS 
-      - Bronchiolo-alveolar carcinoma, type II pneumocyte and goblet cell type 
-      - Bronchiolo-alveolar carcinoma; type II pneumocyte 
-      - Brooke tumor 
+      - Bronchio-alveolar carcinoma, mixed mucinous and non-mucinous
+      - Bronchio-alveolar carcinoma, mucinous
+      - Bronchiolar adenocarcinoma
+      - Bronchiolar carcinoma
+      - Bronchiolo-alveolar adenocarcinoma, NOS
+      - Bronchiolo-alveolar carcinoma, Clara cell
+      - Bronchiolo-alveolar carcinoma, Clara cell and goblet cell type
+      - Bronchiolo-alveolar carcinoma, goblet cell type
+      - Bronchiolo-alveolar carcinoma, indeterminate type
+      - Bronchiolo-alveolar carcinoma, non-mucinous
+      - Bronchiolo-alveolar carcinoma, NOS
+      - Bronchiolo-alveolar carcinoma, type II pneumocyte and goblet cell type
+      - Bronchiolo-alveolar carcinoma; type II pneumocyte
+      - Brooke tumor
       - Brown fat tumor
-      - Burkitt cell leukemia 
+      - Burkitt cell leukemia
       - Burkitt lymphoma, NOS (Includes all variants, see also M-9826/3)
       - Burkitt tumor [obs]
       - Burkitt-like lymphoma
-      - C cell carcinoma 
+      - C cell carcinoma
       - c-ALL
       - Calcifying epithelial odontogenic tumor
-      - Calcifying epithelioma of Malherbe 
-      - Calcifying nested epithelial stromal tumor 
+      - Calcifying epithelioma of Malherbe
+      - Calcifying nested epithelial stromal tumor
       - Calcifying odontogenic cyst
       - Canalicular adenoma
       - Cancer
@@ -1806,12 +1820,12 @@ properties:
       - Carcinoid tumor, argentaffin, malignant
       - Carcinoid tumor, argentaffin, NOS
       - Carcinoid tumor, NOS
-      - Carcinoid tumor, NOS, of appendix 
+      - Carcinoid tumor, NOS, of appendix
       - Carcinoid, NOS
-      - Carcinoid, NOS, of appendix 
+      - Carcinoid, NOS, of appendix
       - Carcinoma in a polyp, NOS
       - Carcinoma in adenomatous polyp
-      - Carcinoma in pleomorphic adenoma 
+      - Carcinoma in pleomorphic adenoma
       - Carcinoma in situ in a polyp, NOS
       - Carcinoma in situ in adenomatous polyp
       - Carcinoma in situ, NOS
@@ -1823,82 +1837,82 @@ properties:
       - Carcinoma with osteoclast-like giant cells
       - Carcinoma with productive fibrosis
       - Carcinoma, anaplastic, NOS
-      - Carcinoma, diffuse type 
-      - Carcinoma, intestinal type 
+      - Carcinoma, diffuse type
+      - Carcinoma, intestinal type
       - Carcinoma, metastatic, NOS
       - Carcinoma, NOS
       - Carcinoma, undifferentiated, NOS
       - Carcinomatosis
       - Carcinosarcoma, embryonal
       - Carcinosarcoma, NOS
-      - Carotid body paraganglioma 
-      - Carotid body tumor 
-      - Cartilaginous exostosis 
+      - Carotid body paraganglioma
+      - Carotid body tumor
+      - Cartilaginous exostosis
       - CASTLE
       - Cavernous hemangioma
       - Cavernous lymphangioma
       - Cellular angiofibroma
-      - Cellular blue nevus 
-      - Cellular ependymoma 
-      - Cellular fibroma 
+      - Cellular blue nevus
+      - Cellular ependymoma
+      - Cellular fibroma
       - Cellular leiomyoma
       - Cellular schwannoma
       - Cementifying fibroma
       - Cemento-ossifying fibroma
       - Cementoblastoma, benign
       - Cementoma, NOS
-      - Central neuroblastoma 
+      - Central neuroblastoma
       - Central neurocytoma
       - Central odontogenic fibroma
-      - Central osteosarcoma 
-      - Central primitive neuroectodermal tumor, NOS 
-      - Cerebellar liponeurocytoma 
-      - Cerebellar sarcoma, NOS 
-      - Ceruminous adenocarcinoma 
-      - Ceruminous adenoma 
-      - Ceruminous carcinoma 
-      - Cervical intraepithelial neoplasia, grade III 
-      - Cervical intraepithelial neoplasia, low grade 
+      - Central osteosarcoma
+      - Central primitive neuroectodermal tumor, NOS
+      - Cerebellar liponeurocytoma
+      - Cerebellar sarcoma, NOS
+      - Ceruminous adenocarcinoma
+      - Ceruminous adenoma
+      - Ceruminous carcinoma
+      - Cervical intraepithelial neoplasia, grade III
+      - Cervical intraepithelial neoplasia, low grade
       - Chemodectoma
-      - Chief cell adenoma 
+      - Chief cell adenoma
       - Chloroma
-      - Cholangiocarcinoma 
-      - Cholangioma 
-      - Chondroblastic osteosarcoma 
-      - Chondroblastoma, malignant 
-      - Chondroblastoma, NOS 
+      - Cholangiocarcinoma
+      - Cholangioma
+      - Chondroblastic osteosarcoma
+      - Chondroblastoma, malignant
+      - Chondroblastoma, NOS
       - Chondroid chordoma
       - Chondroid lipoma
-      - Chondroid syringoma 
-      - Chondroma, NOS 
+      - Chondroid syringoma
+      - Chondroma, NOS
       - Chondromatosis, NOS
-      - Chondromatous giant cell tumor 
-      - Chondromyxoid fibroma 
-      - Chondrosarcoma, NOS 
-      - Chordoid glioma 
-      - Chordoid glioma of third ventricle 
+      - Chondromatous giant cell tumor
+      - Chondromyxoid fibroma
+      - Chondrosarcoma, NOS
+      - Chordoid glioma
+      - Chordoid glioma of third ventricle
       - Chordoid meningioma
       - Chordoma, NOS
-      - Chorioadenoma 
-      - Chorioadenoma destruens 
-      - Chorioangioma 
+      - Chorioadenoma
+      - Chorioadenoma destruens
+      - Chorioangioma
       - Choriocarcinoma combined with embryonal carcinoma
       - Choriocarcinoma combined with other germ cell elements
       - Choriocarcinoma combined with teratorna
       - Choriocarcinoma, NOS
       - Chorioepithelioma
       - Chorionepithelioma
-      - Choroid plexus carcinoma 
-      - Choroid plexus papilloma, anaplastic 
-      - Choroid plexus papilloma, malignant 
-      - Choroid plexus papilloma, NOS 
+      - Choroid plexus carcinoma
+      - Choroid plexus papilloma, anaplastic
+      - Choroid plexus papilloma, malignant
+      - Choroid plexus papilloma, NOS
       - Chromaffin paraganglioma
       - Chromaffin tumor
       - Chromaffinoma
-      - Chromophobe adenocarcinoma 
-      - Chromophobe adenoma 
-      - Chromophobe carcinoma 
-      - Chromophobe cell renal carcinoma 
+      - Chromophobe adenocarcinoma
+      - Chromophobe adenoma
+      - Chromophobe carcinoma
+      - Chromophobe cell renal carcinoma
       - Chronic eosinophilic leukemia, NOS
       - Chronic erythremia [obs]
       - Chronic granulocytic leukemia, BCR/ABL
@@ -1925,9 +1939,9 @@ properties:
       - Chronic myeloproliferative disease, NOS
       - Chronic myeloproliferative disorder
       - Chronic neutrophilic leukemia
-      - CIN III with severe dysplasia 
-      - Cin III, NOS 
-      - Circumscribed arachnoidal cerebellar sarcoma 
+      - CIN III with severe dysplasia
+      - Cin III, NOS
+      - Circumscribed arachnoidal cerebellar sarcoma
       - Classical Hodggkin lymphoma, lymphocyte depletion, diffuse fibrosis
       - Classical Hodgkin lymphoma, lymphocyte depletion, NOS
       - Classical Hodgkin lymphoma, lymphocyte depletion, reticular
@@ -1937,165 +1951,165 @@ properties:
       - Classical Hodgkin lymphoma, nodular sclerosis, grade 1
       - Classical Hodgkin lymphoma, nodular sclerosis, grade 2
       - Classical Hodgkin lymphoma, nodular sclerosis, NOS
-      - Clear cell adenocarcinofibroma 
+      - Clear cell adenocarcinofibroma
       - Clear cell adenocarcinoma, mesonephroid
       - Clear cell adenocarcinoma, NOS
-      - Clear cell adenofibroma 
-      - Clear cell adenofibroma of borderline malignancy 
+      - Clear cell adenofibroma
+      - Clear cell adenofibroma of borderline malignancy
       - Clear cell adenoma
       - Clear cell carcinoma
-      - Clear cell chondrosarcoma 
-      - Clear cell cystadenocarcinofibroma 
-      - Clear cell cystadenofibroma 
-      - Clear cell cystadenofibroma of borderline malignancy 
-      - Clear cell cystadenoma 
-      - Clear cell cystic tumor of borderline malignancy 
-      - Clear cell ependymoma 
-      - Clear cell hidradenoma 
+      - Clear cell chondrosarcoma
+      - Clear cell cystadenocarcinofibroma
+      - Clear cell cystadenofibroma
+      - Clear cell cystadenofibroma of borderline malignancy
+      - Clear cell cystadenoma
+      - Clear cell cystic tumor of borderline malignancy
+      - Clear cell ependymoma
+      - Clear cell hidradenoma
       - Clear cell meningioma
       - Clear cell odontogenic tumor
-      - Clear cell sarcoma of kidney 
+      - Clear cell sarcoma of kidney
       - Clear cell sarcoma, NOS (except of kidney M-8964/3)
-      - Clear cell sarcoma, of tendons and aponeuroses 
+      - Clear cell sarcoma, of tendons and aponeuroses
       - Clear cell tumor, NOS
-      - Cloacogenic carcinoma 
-      - Codman tumor 
-      - Collecting duct carcinoma 
+      - Cloacogenic carcinoma
+      - Codman tumor
+      - Collecting duct carcinoma
       - Colloid adenocarcinoma
-      - Colloid adenoma 
+      - Colloid adenoma
       - Colloid carcinoma
       - Columnar cell papilloma
       - Combined carcinoid and adenocarcinoma
-      - Combined hepatocellular carcinoma and cholangiocarcinoma 
+      - Combined hepatocellular carcinoma and cholangiocarcinoma
       - Combined small cell carcinoma
       - Combined small cell-adenocarcinoma
       - Combined small cell-large carcinoma
       - Combined small cell-squamous cell carcinoma
       - Combined/mixed carcinoid and adenocarcinoma
-      - Comedocarcinoma, noninfiltrating 
-      - Comedocarcinoma, NOS 
+      - Comedocarcinoma, noninfiltrating
+      - Comedocarcinoma, NOS
       - Common ALL
       - Common precursor B ALL
-      - Complete hydatidiform mole 
+      - Complete hydatidiform mole
       - Complex odontoma
       - Composite carcinoid
       - Composite Hodgkin and non-Hodgkin lymphoma
-      - Compound nevus 
+      - Compound nevus
       - Compound odontoma
       - Condylomatous carcinoma
       - Congenital fibrosarcoma
       - Congenital generalized fibromatosis
-      - Congenital peribronchial myofibroblastic tumor 
-      - Conventional central osteosarcoma 
+      - Congenital peribronchial myofibroblastic tumor
+      - Conventional central osteosarcoma
       - Cortical T ALL
-      - CPNET 
-      - Craniopharyngioma 
-      - Craniopharyngioma, adamantinomatous 
-      - Craniopharyngioma, papillary 
-      - Cribriform carcinoma in situ 
+      - CPNET
+      - Craniopharyngioma
+      - Craniopharyngioma, adamantinomatous
+      - Craniopharyngioma, papillary
+      - Cribriform carcinoma in situ
       - Cribriform carcinoma, NOS
-      - Cribriform comedo-type carcinoma 
-      - Cutaneous histiocytoma, NOS 
-      - Cutaneous lymphoma, NOS 
+      - Cribriform comedo-type carcinoma
+      - Cutaneous histiocytoma, NOS
+      - Cutaneous lymphoma, NOS
       - Cutaneous mastocytosis
-      - Cutaneous T-cell lymphoma, NOS 
-      - Cylindrical cell carcinoma 
-      - Cylindrical cell papilloma 
-      - Cylindroma of skin 
+      - Cutaneous T-cell lymphoma, NOS
+      - Cylindrical cell carcinoma
+      - Cylindrical cell papilloma
+      - Cylindroma of skin
       - Cylindroma, NOS (except cylindroma of skin M-8200/0)
-      - Cyst-associated renal cell carcinoma 
+      - Cyst-associated renal cell carcinoma
       - Cystadenocarcinoma, NOS
       - Cystadenofibroma, NOS
       - Cystadenoma, NOS
-      - Cystic astrocytoma 
+      - Cystic astrocytoma
       - Cystic hygroma
-      - Cystic hypersecretory carcinoma 
+      - Cystic hypersecretory carcinoma
       - Cystic lymphangioma
-      - Cystic mesothelioma, benign 
-      - Cystic mesothelioma, NOS 
-      - Cystic partially differentiated nephroblastoma 
+      - Cystic mesothelioma, benign
+      - Cystic mesothelioma, NOS
+      - Cystic partially differentiated nephroblastoma
       - Cystic teratoma, NOS
-      - Cystic tumor of atrio-ventricular node 
+      - Cystic tumor of atrio-ventricular node
       - Cystoma, NOS
-      - Cystosarcoma phyllodes, benign 
-      - Cystosarcoma phyllodes, malignant 
-      - Cystosarcoma phyllodes, NOS 
+      - Cystosarcoma phyllodes, benign
+      - Cystosarcoma phyllodes, malignant
+      - Cystosarcoma phyllodes, NOS
       - Dabska tumor
-      - DCIS, comedo type 
-      - DCIS, NOS 
-      - DCIS, papillary 
-      - Dedifferentiated chondrosarcoma 
+      - DCIS, comedo type
+      - DCIS, NOS
+      - DCIS, papillary
+      - Dedifferentiated chondrosarcoma
       - Dedifferentiated chordoma
       - Dedifferentiated liposarcoma
       - Deep histiocytoma
       - Degenerated schwannoma
       - Dendritic cell sarcoma, NOS
       - Dentinoma
-      - Dermal and epidermal nevus 
-      - Dermal nevus 
-      - Dermatofibroma lenticulare 
-      - Dermatofibroma, NOS 
-      - Dermatofibrosarcoma protuberans, NOS 
-      - Dermatofibrosarcoma, NOS 
-      - Dermoid cyst with malignant transformation 
+      - Dermal and epidermal nevus
+      - Dermal nevus
+      - Dermatofibroma lenticulare
+      - Dermatofibroma, NOS
+      - Dermatofibrosarcoma protuberans, NOS
+      - Dermatofibrosarcoma, NOS
+      - Dermoid cyst with malignant transformation
       - Dermoid cyst with secondary tumor
       - Dermoid cyst, NOS
       - Dermoid, NOS
       - Desmoid, NOS
       - Desmoplastic fibroma
-      - Desmoplastic infantile astrocytoma 
-      - Desmoplastic infantile ganglioglioma 
-      - Desmoplastic medulloblastoma 
-      - Desmoplastic melanoma, amelanotic 
-      - Desmoplastic melanoma, malignant 
+      - Desmoplastic infantile astrocytoma
+      - Desmoplastic infantile ganglioglioma
+      - Desmoplastic medulloblastoma
+      - Desmoplastic melanoma, amelanotic
+      - Desmoplastic melanoma, malignant
       - Desmoplastic mesothelioma
-      - Desmoplastic nodular medulloblastoma 
+      - Desmoplastic nodular medulloblastoma
       - Desmoplastic small round cell tumor
       - Di Guglielmo disease [obs]
-      - Diffuse astrocytoma 
-      - Diffuse astrocytoma, low grade 
+      - Diffuse astrocytoma
+      - Diffuse astrocytoma, low grade
       - Diffuse cutaneous mastocytosis
       - Diffuse intraductal papillomatosis
       - Diffuse large B-cell lymphoma associated with chronic inflammation
       - Diffuse large B-cell lymphoma, NOS
-      - Diffuse melanocytosis 
+      - Diffuse melanocytosis
       - Diffuse meningiomatosis
-      - Digital papillary adenocarcinoma 
-      - Diktyoma, benign 
-      - Diktyoma, malignant 
-      - DIN 3 
+      - Digital papillary adenocarcinoma
+      - Diktyoma, benign
+      - Diktyoma, malignant
+      - DIN 3
       - Duct adenocarcinoma, NOS
       - Duct adenoma, NOS
       - Duct carcinoma, desmoplastic type
       - Duct carcinoma, NOS
       - Duct cell carcinoma
-      - Ductal carcinoma in situ, comedo type 
-      - Ductal carcinoma in situ, cribriform type 
-      - Ductal carcinoma in situ, micropapillary 
-      - Ductal carcinoma in situ, NOS 
-      - Ductal carcinoma in situ, papillary 
-      - Ductal carcinoma in situ, solid type 
-      - Ductal carcinoma, cribriform type 
+      - Ductal carcinoma in situ, comedo type
+      - Ductal carcinoma in situ, cribriform type
+      - Ductal carcinoma in situ, micropapillary
+      - Ductal carcinoma in situ, NOS
+      - Ductal carcinoma in situ, papillary
+      - Ductal carcinoma in situ, solid type
+      - Ductal carcinoma, cribriform type
       - Ductal carcinoma, NOS
-      - Ductal intraepithelial neoplasia 3 
+      - Ductal intraepithelial neoplasia 3
       - Ductal papilloma
       - Dysembryoplastic neuroepithelial tumor
       - Dysgerminoma
-      - Dysplastic gangliocytoma of cerebellum (Lhermitte-Duclos) 
-      - Dysplastic nevus 
+      - Dysplastic gangliocytoma of cerebellum (Lhermitte-Duclos)
+      - Dysplastic nevus
       - EBV positive diffuse large B-cell lymphoma of the elderly
       - EC cell carcinoid
-      - Ecchondroma 
-      - Ecchondrosis 
-      - Eccrine acrospiroma 
-      - Eccrine adenocarcinoma 
-      - Eccrine cystadenoma 
-      - Eccrine dermal cylindroma 
-      - Eccrine papillary adenocarcinoma 
-      - Eccrine papillary adenoma 
-      - Eccrine poroma 
+      - Ecchondroma
+      - Ecchondrosis
+      - Eccrine acrospiroma
+      - Eccrine adenocarcinoma
+      - Eccrine cystadenoma
+      - Eccrine dermal cylindroma
+      - Eccrine papillary adenocarcinoma
+      - Eccrine papillary adenoma
+      - Eccrine poroma
       - Eccrine poroma, malignant
-      - Eccrine spiradenoma 
+      - Eccrine spiradenoma
       - ECL cell carcinoid, malignant
       - ECL cell carcinoid, NOS
       - Ectomesenchymoma
@@ -2106,22 +2120,22 @@ properties:
       - Embryonal carcinoma, infantile
       - Embryonal carcinoma, NOS
       - Embryonal carcinoma, polyembryonal type
-      - Embryonal hepatoma 
+      - Embryonal hepatoma
       - Embryonal rhabdomyosarcoma, NOS
       - Embryonal rhabdomyosarcoma, pleomorphic
       - Embryonal sarcoma
       - Embryonal teratoma
-      - Enchondroma 
+      - Enchondroma
       - Endocrine adenomatosis
       - Endocrine tumor, functioning, NOS
       - Endodermal sinus tumor
-      - Endolymphatic stromal myosis 
-      - Endometrial sarcoma, NOS 
-      - Endometrial stromal nodule 
-      - Endometrial stromal sarcoma, high grade 
-      - Endometrial stromal sarcoma, low grade 
-      - Endometrial stromal sarcoma, NOS 
-      - Endometrial stromatosis 
+      - Endolymphatic stromal myosis
+      - Endometrial sarcoma, NOS
+      - Endometrial stromal nodule
+      - Endometrial stromal sarcoma, high grade
+      - Endometrial stromal sarcoma, low grade
+      - Endometrial stromal sarcoma, NOS
+      - Endometrial stromatosis
       - Endometrioid adenocarcinoma, ciliated cell variant
       - Endometrioid adenocarcinoma, NOS
       - Endometrioid adenocarcinoma, secretory variant
@@ -2147,14 +2161,14 @@ properties:
       - Enteroglucagonoma, NOS
       - Enteropathy associated T-cell lymphoma
       - Enteropathy type intestinal T-cell lymphoma
-      - Eosinophil adenocarcinoma 
-      - Eosinophil adenoma 
-      - Eosinophil carcinoma 
+      - Eosinophil adenocarcinoma
+      - Eosinophil adenoma
+      - Eosinophil carcinoma
       - Eosinophilic granuloma
       - Eosinophilic leukemia
-      - Ependymoblastoma 
-      - Ependymoma, anaplastic 
-      - Ependymoma, NOS 
+      - Ependymoblastoma
+      - Ependymoma, anaplastic
+      - Ependymoma, NOS
       - Epidermoid carcinoma in situ with questionable stromal invasion
       - Epidermoid carcinoma in situ, NOS
       - Epidermoid carcinoma, keratinizing
@@ -2162,13 +2176,13 @@ properties:
       - Epidermoid carcinoma, NOS
       - Epidermoid carcinoma, small cell, nonkeratinizing
       - Epidermoid carcinoma, spindle cell
-      - Epithelial ependymoma 
+      - Epithelial ependymoma
       - Epithelial tumor, benign
       - Epithelial tumor, malignant
       - Epithelial-myoepithelial carcinoma
-      - Epithelioid and spindle cell nevus 
+      - Epithelioid and spindle cell nevus
       - Epithelioid cell melanoma
-      - Epithelioid cell nevus 
+      - Epithelioid cell nevus
       - Epithelioid cell sarcoma
       - Epithelioid hemangioendothelioma, malignant
       - Epithelioid hemangioendothelioma, NOS
@@ -2180,22 +2194,22 @@ properties:
       - Epithelioid mesothelioma, NOS
       - Epithelioid MPNST
       - Epithelioid sarcoma
-      - Epithelioma adenoides cysticum 
+      - Epithelioma adenoides cysticum
       - Epithelioma, benign
       - Epithelioma, malignant
       - Epithelioma, NOS
       - Erythremic myelosis, NOS
       - Erythroleukemia
-      - Esophageal glandular dysplasia (intraepithelial neoplasia), high grade 
-      - Esophageal glandular dysplasia (intraepithelial neoplasia), low grade 
-      - Esophageal intraepithelial neoplasia, high grade 
-      - Esophageal squamous intraepithelial neoplasia (dysplasia), high grade 
-      - Esophageal squamous intraepithelial neoplasia (dysplasia), low grade 
+      - Esophageal glandular dysplasia (intraepithelial neoplasia), high grade
+      - Esophageal glandular dysplasia (intraepithelial neoplasia), low grade
+      - Esophageal intraepithelial neoplasia, high grade
+      - Esophageal squamous intraepithelial neoplasia (dysplasia), high grade
+      - Esophageal squamous intraepithelial neoplasia (dysplasia), low grade
       - Essential hemorrhagic thrombocythaemia
       - Essential thrombocythemia
-      - Esthesioneuroblastoma 
-      - Esthesioneurocytoma 
-      - Esthesioneuroepithelioma 
+      - Esthesioneuroblastoma
+      - Esthesioneurocytoma
+      - Esthesioneuroepithelioma
       - Ewing sarcoma
       - Ewing tumor
       - Extra-abdominal desmoid
@@ -2220,29 +2234,29 @@ properties:
       - FAB M6
       - FAB M7
       - FAB MO
-      - Familial polyposis coli 
+      - Familial polyposis coli
       - Fascial fibroma
       - Fascial fibrosarcoma
       - Fetal adenocarcinoma
-      - Fetal adenoma 
+      - Fetal adenoma
       - Fetal fat cell lipoma
       - Fetal lipoma, NOS
       - Fetal lipomatosis
       - Fetal rhabdomyoma
-      - Fibrillary astrocytoma 
+      - Fibrillary astrocytoma
       - Fibro-osteoma
-      - Fibroadenoma, NOS 
+      - Fibroadenoma, NOS
       - Fibroameloblastic odontoma
       - Fibroblastic liposarcoma
       - Fibroblastic meningioma
-      - Fibroblastic osteosarcoma 
+      - Fibroblastic osteosarcoma
       - Fibroblastic reticular cell tumor
-      - Fibrochondrosarcoma 
+      - Fibrochondrosarcoma
       - Fibroepithelial basal cell carcinoma, Pinkus type
       - Fibroepithelioma of Pinkus type
       - Fibroepithelioma, NOS
-      - Fibrofolliculoma 
-      - Fibroid uterus 
+      - Fibrofolliculoma
+      - Fibroid uterus
       - Fibrolipoma
       - Fibroliposarcoma
       - Fibroma, NOS
@@ -2251,50 +2265,50 @@ properties:
       - Fibromyxoma
       - Fibromyxosarcoma
       - Fibrosarcoma, NOS
-      - Fibrous astrocytoma 
-      - Fibrous histiocytoma of tendon sheath 
+      - Fibrous astrocytoma
+      - Fibrous histiocytoma of tendon sheath
       - Fibrous histiocytoma, NOS
       - Fibrous meningioma
       - Fibrous mesothelioma, benign
       - Fibrous mesothelioma, malignant
       - Fibrous mesothelioma, NOS
-      - Fibrous papule of nose 
+      - Fibrous papule of nose
       - Fibroxanthoma, malignant
       - Fibroxanthoma, NOS
       - Flat adenoma
-      - Flat intraepithelial glandular neoplasia, high grade 
-      - Flat intraepithelial neoplasia (dysplasia), high grade 
+      - Flat intraepithelial glandular neoplasia, high grade
+      - Flat intraepithelial neoplasia (dysplasia), high grade
       - Flat intraepithelial neoplasia, high grade
       - Florid osseous dysplasia
-      - Follicular adenocarcinoma, moderately differentiated 
-      - Follicular adenocarcinoma, NOS 
-      - Follicular adenocarcinoma, trabecular 
-      - Follicular adenocarcinoma, well differentiated 
-      - Follicular adenoma 
-      - Follicular adenoma, oxyphilic cell 
-      - Follicular carcinoma, encapsulated 
-      - Follicular carcinoma, minimally invasive 
-      - Follicular carcinoma, moderately differentiated 
-      - Follicular carcinoma, NOS 
-      - Follicular carcinoma, oxyphilic cell 
-      - Follicular carcinoma, trabecular 
-      - Follicular carcinoma, well differentiated 
+      - Follicular adenocarcinoma, moderately differentiated
+      - Follicular adenocarcinoma, NOS
+      - Follicular adenocarcinoma, trabecular
+      - Follicular adenocarcinoma, well differentiated
+      - Follicular adenoma
+      - Follicular adenoma, oxyphilic cell
+      - Follicular carcinoma, encapsulated
+      - Follicular carcinoma, minimally invasive
+      - Follicular carcinoma, moderately differentiated
+      - Follicular carcinoma, NOS
+      - Follicular carcinoma, oxyphilic cell
+      - Follicular carcinoma, trabecular
+      - Follicular carcinoma, well differentiated
       - Follicular dendritic cell sarcoma
       - Follicular dendritic cell tumor
-      - Follicular fibroma 
+      - Follicular fibroma
       - Follicular lymphoma, grade 1
       - Follicular lymphoma, grade 2
       - Follicular lymphoma, grade 3
       - Follicular lymphoma, grade 3A
       - Follicular lymphoma, grade 3B
-      - Follicular lymphoma, NOS 
+      - Follicular lymphoma, NOS
       - Follicular lymphoma, small cleaved cell
-      - Folliculome lipidique 
+      - Folliculome lipidique
       - Franklin disease
       - G cell tumor, malignant
       - G cell tumor, NOS
       - Gamma heavy chain disease
-      - Gangliocytic paraganglioma 
+      - Gangliocytic paraganglioma
       - Gangliocytoma
       - Ganglioglioma, anaplastic
       - Ganglioglioma, NOS
@@ -2315,27 +2329,27 @@ properties:
       - Gastrointestinal stromal tumor, uncertain malignant potential
       - Gelatinous adenocarcinoma [obs]
       - Gelatinous carcinoma [obs]
-      - Gemistocytic astrocytoma 
-      - Gemistocytoma 
-      - Genital rhabdomyoma 
-      - Germ cell tumor, nonseminomatous 
+      - Gemistocytic astrocytoma
+      - Gemistocytoma
+      - Genital rhabdomyoma
+      - Germ cell tumor, nonseminomatous
       - Germ cell tumor, NOS
       - Germinoma
       - Giant cell and spindle cell carcinoma
       - Giant cell angiofibroma
       - Giant cell carcinoma
       - Giant cell fibroblastoma
-      - Giant cell glioblastoma 
+      - Giant cell glioblastoma
       - Giant cell sarcoma (except of bone M-9250/3)
-      - Giant cell sarcoma of bone 
-      - Giant cell tumor of bone, malignant 
-      - Giant cell tumor of bone, NOS 
+      - Giant cell sarcoma of bone
+      - Giant cell tumor of bone, malignant
+      - Giant cell tumor of bone, NOS
       - Giant cell tumor of soft parts, NOS
-      - Giant cell tumor of tendon sheath 
-      - Giant cell tumor of tendon sheath, malignant 
-      - Giant fibroadenoma 
-      - Giant osteoid osteoma 
-      - Giant pigmented nevus, NOS 
+      - Giant cell tumor of tendon sheath
+      - Giant cell tumor of tendon sheath, malignant
+      - Giant fibroadenoma
+      - Giant osteoid osteoma
+      - Giant pigmented nevus, NOS
       - Gigantiform cementoma
       - GIST, benign
       - GIST, malignant
@@ -2347,25 +2361,25 @@ properties:
       - Glandular intraepithelial neoplasia, low grade
       - Glandular papilloma
       - Glassy cell carcinoma
-      - Glioblastoma 
-      - Glioblastoma multiforme 
-      - Glioblastoma with sarcomatous component 
-      - Gliofibroma 
-      - Glioma, malignant 
+      - Glioblastoma
+      - Glioblastoma multiforme
+      - Glioblastoma with sarcomatous component
+      - Gliofibroma
+      - Glioma, malignant
       - Glioma, NOS (except nasal glioma, not neoplastic)
-      - Gliomatosis cerebri 
+      - Gliomatosis cerebri
       - Glioneuroma [obs]
-      - Gliosarcoma 
+      - Gliosarcoma
       - Glomangioma
       - Glomangiomyoma
       - Glomangiosarcoma
       - Glomoid sarcoma
-      - Glomus jugulare tumor, NOS 
+      - Glomus jugulare tumor, NOS
       - Glomus tumor, malignant
       - Glomus tumor, NOS
       - Glucagon-like peptide-producing tumor
-      - Glucagonoma, malignant 
-      - Glucagonoma, NOS 
+      - Glucagonoma, malignant
+      - Glucagonoma, NOS
       - Glycogen-rich carcinoma
       - Glycogenic rhabdomyoma
       - Goblet cell carcinoid
@@ -2376,28 +2390,28 @@ properties:
       - Granular cell carcinoma
       - Granular cell myoblastoma, malignant
       - Granular cell myoblastoma, NOS
-      - Granular cell tumor of the sellar region 
+      - Granular cell tumor of the sellar region
       - Granular cell tumor, malignant
       - Granular cell tumor, NOS
       - Granulocytic leukemia, NOS
       - Granulocytic sarcoma
-      - Granulosa cell carcinoma 
-      - Granulosa cell tumor, adult type 
-      - Granulosa cell tumor, juvenile 
-      - Granulosa cell tumor, malignant 
-      - Granulosa cell tumor, NOS 
-      - Granulosa cell tumor, sarcomatoid 
-      - Granulosa cell-theca cell tumor 
-      - Grawitz tumor 
-      - Gynandroblastoma 
+      - Granulosa cell carcinoma
+      - Granulosa cell tumor, adult type
+      - Granulosa cell tumor, juvenile
+      - Granulosa cell tumor, malignant
+      - Granulosa cell tumor, NOS
+      - Granulosa cell tumor, sarcomatoid
+      - Granulosa cell-theca cell tumor
+      - Grawitz tumor
+      - Gynandroblastoma
       - Haemangioblastoma
       - Haemangiosarcoma
       - Hairy cell leukaemia variant
-      - Hairy cell leukemia 
+      - Hairy cell leukemia
       - Hairy cell leukemia variant
-      - Hairy nevus 
-      - Halo nevus 
-      - Hand-Schuller-Christian disease 
+      - Hairy nevus
+      - Halo nevus
+      - Hand-Schuller-Christian disease
       - Heavy chain disease, NOS
       - Hemangioblastic meningioma [obs]
       - Hemangioendothelial sarcoma
@@ -2406,46 +2420,46 @@ properties:
       - Hemangioendothelioma, NOS
       - Hemangioma simplex
       - Hemangioma, NOS
-      - Hemangiopericytic meningioma 
+      - Hemangiopericytic meningioma
       - Hemangiopericytoma, benign
       - Hemangiopericytoma, malignant
       - Hemangiopericytoma, NOS
       - Hemolymphangioma
-      - Hepatoblastoma 
-      - Hepatoblastoma, epithelioid 
-      - Hepatoblastoma, mixed epithelial-mesenchymal 
-      - Hepatocarcinoma 
-      - Hepatocellular adenoma 
-      - Hepatocellular carcinoma, clear cell type 
-      - Hepatocellular carcinoma, fibrolamellar 
-      - Hepatocellular carcinoma, NOS 
-      - Hepatocellular carcinoma, pleomorphic type 
-      - Hepatocellular carcinoma, sarcomatoid 
-      - Hepatocellular carcinoma, scirrhous 
-      - Hepatocellular carcinoma, spindle cell variant 
-      - Hepatocholangiocarcinoma 
+      - Hepatoblastoma
+      - Hepatoblastoma, epithelioid
+      - Hepatoblastoma, mixed epithelial-mesenchymal
+      - Hepatocarcinoma
+      - Hepatocellular adenoma
+      - Hepatocellular carcinoma, clear cell type
+      - Hepatocellular carcinoma, fibrolamellar
+      - Hepatocellular carcinoma, NOS
+      - Hepatocellular carcinoma, pleomorphic type
+      - Hepatocellular carcinoma, sarcomatoid
+      - Hepatocellular carcinoma, scirrhous
+      - Hepatocellular carcinoma, spindle cell variant
+      - Hepatocholangiocarcinoma
       - Hepatoid adenocarcinoma
       - Hepatoid carcinoma
       - Hepatoid yolk sac tumor
-      - Hepatoma, benign 
-      - Hepatoma, malignant 
-      - Hepatoma, NOS 
+      - Hepatoma, benign
+      - Hepatoma, malignant
+      - Hepatoma, NOS
       - Hepatosplenic T-cell lymphoma
       - Hepatosplenic gamma-delta cell lymphoma
       - Hibernoma
-      - Hidradenocarcinoma 
+      - Hidradenocarcinoma
       - Hidradenoma papilliferum
-      - Hidradenoma, NOS 
-      - Hidrocystoma 
-      - High grade surface osteosarcoma 
-      - Hilar cell tumor 
-      - Hilus cell tumor 
+      - Hidradenoma, NOS
+      - Hidrocystoma
+      - High grade surface osteosarcoma
+      - Hilar cell tumor
+      - Hilus cell tumor
       - Histiocyte-rich large B-cell lymphoma
       - Histiocytic medullary reticulosis [obs]
       - Histiocytic sarcoma
       - Histiocytoid hemangioma
       - Histiocytoma, NOS
-      - Histiocytosis X, NOS 
+      - Histiocytosis X, NOS
       - Hodgkin disease, lymphocyte predominance, diffuse [obs]
       - Hodgkin disease, lymphocyte predominance, NOS [obs]
       - Hodgkin disease, lymphocytic-histiocytic predominance [obs]
@@ -2471,19 +2485,19 @@ properties:
       - Hodgkin paragranuloma, nodular [obs]
       - Hodgkin paragranuloma, NOS [obs]
       - Hodgkin sarcoma [obs]
-      - Hurthle cell adenocarcinoma 
-      - Hurthle cell adenoma 
-      - Hurthle cell carcinoma 
-      - Hurthle cell tumor 
-      - Hutchinson melanotic freckle, NOS 
-      - Hyalinizing trabecular adenoma 
-      - Hydatid mole 
-      - Hydatidiform mole, NOS 
+      - Hurthle cell adenocarcinoma
+      - Hurthle cell adenoma
+      - Hurthle cell carcinoma
+      - Hurthle cell tumor
+      - Hutchinson melanotic freckle, NOS
+      - Hyalinizing trabecular adenoma
+      - Hydatid mole
+      - Hydatidiform mole, NOS
       - Hydroa vacciniforme-like lymphoma
       - Hygroma, NOS
       - Hypereosinophilic syndrome
       - Hypernephroid tumor [obs]
-      - Hypernephroma 
+      - Hypernephroma
       - Idiopathic hemorrhagic thrombocythaemia
       - Idiopathic thrombocythemia
       - Immature teratoma, malignant
@@ -2492,7 +2506,7 @@ properties:
       - Immunocytoma [obs]
       - Immunoglobulin deposition disease
       - Immunoproliferative disease, NOS
-      - Immunoproliferative small intestinal disease 
+      - Immunoproliferative small intestinal disease
       - Indeterminate dendritic cell tumor
       - Indolent systemic mastocytosis
       - Infantile fibrosarcoma
@@ -2500,200 +2514,200 @@ properties:
       - Infantile myofibromatosis
       - Infiltrating and papillary adenocarcinoma
       - Infiltrating angiolipoma
-      - Infiltrating basal cell carcinoma, non-sclerosing 
-      - Infiltrating basal cell carcinoma, NOS 
-      - Infiltrating basal cell carcinoma, sclerosing 
-      - Infiltrating duct adenocarcinoma 
-      - Infiltrating duct and colloid carcinoma 
-      - Infiltrating duct and cribriform carcinoma 
-      - Infiltrating duct and lobular carcinoma 
-      - Infiltrating duct and lobular carcinoma in situ 
-      - Infiltrating duct and mucinous carcinoma 
-      - Infiltrating duct and tubular carcinoma 
-      - Infiltrating duct carcinoma, NOS 
-      - Infiltrating duct mixed with other types of carcinoma 
-      - Infiltrating ductular carcinoma 
+      - Infiltrating basal cell carcinoma, non-sclerosing
+      - Infiltrating basal cell carcinoma, NOS
+      - Infiltrating basal cell carcinoma, sclerosing
+      - Infiltrating duct adenocarcinoma
+      - Infiltrating duct and colloid carcinoma
+      - Infiltrating duct and cribriform carcinoma
+      - Infiltrating duct and lobular carcinoma
+      - Infiltrating duct and lobular carcinoma in situ
+      - Infiltrating duct and mucinous carcinoma
+      - Infiltrating duct and tubular carcinoma
+      - Infiltrating duct carcinoma, NOS
+      - Infiltrating duct mixed with other types of carcinoma
+      - Infiltrating ductular carcinoma
       - Infiltrating lipoma
-      - Infiltrating lobular carcinoma and ductal carcinoma in situ 
-      - Infiltrating lobular carcinoma, NOS 
-      - Infiltrating lobular mixed with other types of carcinoma 
+      - Infiltrating lobular carcinoma and ductal carcinoma in situ
+      - Infiltrating lobular carcinoma, NOS
+      - Infiltrating lobular mixed with other types of carcinoma
       - Infiltrating papillary adenocarcinoma
-      - Inflammatory adenocarcinoma 
-      - Inflammatory carcinoma 
+      - Inflammatory adenocarcinoma
+      - Inflammatory carcinoma
       - Inflammatory liposarcoma
       - Inflammatory myofibroblastic tumor
-      - Insular carcinoma 
-      - Insulinoma, malignant 
-      - Insulinoma, NOS 
+      - Insular carcinoma
+      - Insulinoma, malignant
+      - Insulinoma, NOS
       - Interdigitating cell sarcoma
       - Interdigitating dendritic cell sarcoma
-      - Intermediate and giant congenital nevus 
+      - Intermediate and giant congenital nevus
       - Interstitial cell tumor, benign
       - Interstitial cell tumor, malignant
       - Interstitial cell tumor, NOS
       - Intestinal T-cell lymphoma
-      - Intracanalicular fibroadenoma 
-      - Intracortical osteosarcoma 
+      - Intracanalicular fibroadenoma
+      - Intracortical osteosarcoma
       - Intracystic carcinoma, NOS
       - Intracystic papillary adenocarcinoma
       - Intracystic papillary adenoma
-      - Intracystic papillary neoplasm with associated invasive carcinoma 
-      - Intracystic papillary neoplasm with high grade intraepithelial neoplasia 
-      - Intracystic papillary neoplasm with intermediate grade intraepithelial neoplasia 
-      - Intracystic papillary neoplasm with low grade intraepithelial neoplasia 
-      - Intracystic papillary tumor with high grade dysplasia 
-      - Intracystic papillary tumor with high grade entraepithelial neoplasia 
-      - Intracystic papillary tumor with high grade intraepithelial neoplasia 
+      - Intracystic papillary neoplasm with associated invasive carcinoma
+      - Intracystic papillary neoplasm with high grade intraepithelial neoplasia
+      - Intracystic papillary neoplasm with intermediate grade intraepithelial neoplasia
+      - Intracystic papillary neoplasm with low grade intraepithelial neoplasia
+      - Intracystic papillary tumor with high grade dysplasia
+      - Intracystic papillary tumor with high grade entraepithelial neoplasia
+      - Intracystic papillary tumor with high grade intraepithelial neoplasia
       - Intracystic papilloma
-      - Intradermal nevus 
+      - Intradermal nevus
       - Intraductal adenocarcinoma, noninfiltrating, NOS
-      - Intraductal and lobular carcinoma 
-      - Intraductal carcinoma and lobular carcinoma in situ 
-      - Intraductal carcinoma, clinging 
+      - Intraductal and lobular carcinoma
+      - Intraductal carcinoma and lobular carcinoma in situ
+      - Intraductal carcinoma, clinging
       - Intraductal carcinoma, noninfiltrating, NOS
       - Intraductal carcinoma, NOS
       - Intraductal carcinoma, solid type
-      - Intraductal micropapillary carcinoma 
-      - Intraductal papillary adenocarcinoma with invasion 
-      - Intraductal papillary adenocarcinoma, NOS 
-      - Intraductal papillary carcinoma 
+      - Intraductal micropapillary carcinoma
+      - Intraductal papillary adenocarcinoma with invasion
+      - Intraductal papillary adenocarcinoma, NOS
+      - Intraductal papillary carcinoma
       - Intraductal papillary mucinous neoplasm with an associated invasive carcinoma
       - Intraductal papillary mucinous neoplasm with high grade dysplasia
       - Intraductal papillary neoplasm with associated invasive carcinoma
       - Intraductal papillary neoplasm with high grade dysplasia
       - Intraductal papillary neoplasm with high grade intraepithelial neoplasia
-      - Intraductal papillary neoplasm with intermediate grade neoplasia 
-      - Intraductal papillary neoplasm with low grade intraepithelial neoplasia 
+      - Intraductal papillary neoplasm with intermediate grade neoplasia
+      - Intraductal papillary neoplasm with low grade intraepithelial neoplasia
       - Intraductal papillary neoplasm, NOS
       - Intraductal papillary tumor with high grade dysplasia
       - Intraductal papillary tumor with high grade intraepithelial neoplasia
-      - Intraductal papillary-mucinous adenoma 
-      - Intraductal papillary-mucinous carcinoma, invasive 
-      - Intraductal papillary-mucinous carcinoma, non-invasive 
-      - Intraductal papillary-mucinous neoplasm with low grade dysplasia 
-      - Intraductal papillary-mucinous neoplasm with moderate dysplasia 
-      - Intraductal papillary-mucinous tumor with intermediate dysplasia 
-      - Intraductal papillary-mucinous tumor with low grade dysplasia 
-      - Intraductal papillary-mucinous tumor with moderate dysplasia 
+      - Intraductal papillary-mucinous adenoma
+      - Intraductal papillary-mucinous carcinoma, invasive
+      - Intraductal papillary-mucinous carcinoma, non-invasive
+      - Intraductal papillary-mucinous neoplasm with low grade dysplasia
+      - Intraductal papillary-mucinous neoplasm with moderate dysplasia
+      - Intraductal papillary-mucinous tumor with intermediate dysplasia
+      - Intraductal papillary-mucinous tumor with low grade dysplasia
+      - Intraductal papillary-mucinous tumor with moderate dysplasia
       - Intraductal papilloma
       - Intraductal papillomatosis, NOS
       - Intraductal tubular-papillary neoplasm, high grade
       - Intraductal tubular-papillary neoplasm, low grade
       - Intraepidermal carcinoma, NOS
-      - Intraepidermal epithelioma of Jadassohn 
-      - Intraepidermal nevus 
-      - Intraepidermal squamous cell carcinoma, Bowen type 
+      - Intraepidermal epithelioma of Jadassohn
+      - Intraepidermal nevus
+      - Intraepidermal squamous cell carcinoma, Bowen type
       - Intraepithelial carcinoma, NOS
       - Intraepithelial squamous cell carcinoma
-      - Intraglandular papillary neoplasm with low grade intraepithelial neoplasia 
+      - Intraglandular papillary neoplasm with low grade intraepithelial neoplasia
       - Intramuscular hemangioma
       - Intramuscular lipoma
       - Intraneural perineurioma
-      - Intraosseous low grade osteosarcoma 
-      - Intraosseous well differentiated osteosarcoma 
-      - Intratubular germ cell neoplasia 
-      - Intratubular malignant germ cells 
+      - Intraosseous low grade osteosarcoma
+      - Intraosseous well differentiated osteosarcoma
+      - Intratubular germ cell neoplasia
+      - Intratubular malignant germ cells
       - Intravascular B-cell lymphoma
-      - Intravascular bronchial alveolar tumor 
-      - Intravascular large B-cell lymphoma 
+      - Intravascular bronchial alveolar tumor
+      - Intravascular large B-cell lymphoma
       - Intravascular leiomyomatosis
       - Invasive fibroma
-      - Invasive hydatidiform mole 
-      - Invasive mole, NOS 
-      - Involuting nevus 
-      - Islet cell adenocarcinoma 
-      - Islet cell adenoma 
-      - Islet cell adenomatosis 
-      - Islet cell carcinoma 
-      - Islet cell tumor, benign 
-      - Islet cell tumor, NOS 
-      - Jadassohn blue nevus 
-      - Jugular paraganglioma 
-      - Jugulotympanic paraganglioma 
-      - Junction nevus 
-      - Junctional nevus, NOS 
+      - Invasive hydatidiform mole
+      - Invasive mole, NOS
+      - Involuting nevus
+      - Islet cell adenocarcinoma
+      - Islet cell adenoma
+      - Islet cell adenomatosis
+      - Islet cell carcinoma
+      - Islet cell tumor, benign
+      - Islet cell tumor, NOS
+      - Jadassohn blue nevus
+      - Jugular paraganglioma
+      - Jugulotympanic paraganglioma
+      - Junction nevus
+      - Junctional nevus, NOS
       - Juvenile angiofibroma
-      - Juvenile astrocytoma 
-      - Juvenile carcinoma of breast 
+      - Juvenile astrocytoma
+      - Juvenile carcinoma of breast
       - Juvenile chronic myelomonocytic leukemia
-      - Juvenile fibroadenoma 
+      - Juvenile fibroadenoma
       - Juvenile hemangioma
       - Juvenile histiocytoma
-      - Juvenile melanoma 
+      - Juvenile melanoma
       - Juvenile myelomonocytic leukemia
-      - Juvenile nevus 
-      - Juxtacortical chondroma 
-      - Juxtacortical chondrosarcoma 
-      - Juxtacortical osteosarcoma 
-      - Juxtaglomerular tumor 
+      - Juvenile nevus
+      - Juxtacortical chondroma
+      - Juxtacortical chondrosarcoma
+      - Juxtacortical osteosarcoma
+      - Juxtaglomerular tumor
       - Kaposi sarcoma
       - Kaposiform hemangioendothelioma
       - Keratotoc papilloma
-      - Klatskin tumor 
+      - Klatskin tumor
       - Krukenberg tumor
-      - Kupffer cell sarcoma 
+      - Kupffer cell sarcoma
       - L-cell tumor
-      - Lactating adenoma 
-      - Langerhans cell granulomatosis 
-      - Langerhans cell granulomatosis, unifocal 
-      - Langerhans cell histiocytosis, disseminated 
-      - Langerhans cell histiocytosis, generalized 
-      - Langerhans cell histiocytosis, mono-ostotic 
-      - Langerhans cell histiocytosis, multifocal 
-      - Langerhans cell histiocytosis, NOS 
-      - Langerhans cell histiocytosis, poly-ostotic 
-      - Langerhans cell histiocytosis, unifocal 
+      - Lactating adenoma
+      - Langerhans cell granulomatosis
+      - Langerhans cell granulomatosis, unifocal
+      - Langerhans cell histiocytosis, disseminated
+      - Langerhans cell histiocytosis, generalized
+      - Langerhans cell histiocytosis, mono-ostotic
+      - Langerhans cell histiocytosis, multifocal
+      - Langerhans cell histiocytosis, NOS
+      - Langerhans cell histiocytosis, poly-ostotic
+      - Langerhans cell histiocytosis, unifocal
       - Langerhans cell sarcoma
       - Large B-cell lymphoma arising in HHV8-associated multicentric Castleman disease
       - Large cell (Ki-1+) lymphoma
       - Large cell calcifying Sertoli cell tumor
       - Large cell carcinoma with rhabdoid phenotype
       - Large cell carcinoma, NOS
-      - Large cell medulloblastoma 
+      - Large cell medulloblastoma
       - Large cell neuroendocrine carcinoma
       - Large granular lymphocytosis, NOS
-      - LCIS, NOS 
+      - LCIS, NOS
       - Leiomyoblastoma
       - Leiomyofibroma
       - Leiomyoma, NOS
       - Leiomyomatosis, NOS
       - Leiomyosarcoma, NOS
       - Lennert lymphoma
-      - Lentigo maligna 
-      - Lentigo maligna melanoma 
+      - Lentigo maligna
+      - Lentigo maligna melanoma
       - Leptomeningeal sarcoma
-      - Letterer-Siwe disease 
+      - Letterer-Siwe disease
       - Leukaemic reticuloendotheliosis
       - Leukemia, NOS
-      - Leydig cell tumor, benign 
-      - Leydig cell tumor, malignant 
-      - Leydig cell tumor, NOS 
-      - Linitis plastica 
-      - Lipid cell tumor of ovary 
-      - Lipid-rich carcinoma 
-      - Lipid-rich Sertoli cell tumor 
+      - Leydig cell tumor, benign
+      - Leydig cell tumor, malignant
+      - Leydig cell tumor, NOS
+      - Linitis plastica
+      - Lipid cell tumor of ovary
+      - Lipid-rich carcinoma
+      - Lipid-rich Sertoli cell tumor
       - Lipoadenoma
       - Lipoarcoma, well differentiated
       - Lipoblastoma
       - Lipoblastomatosis
-      - Lipoid cell tumor of ovary 
+      - Lipoid cell tumor of ovary
       - Lipoleiomyoma
       - Lipoma-like liposarcoma
       - Lipoma, NOS
-      - Lipomatous medulloblastoma 
+      - Lipomatous medulloblastoma
       - Liposarcoma, differentiated
       - Liposarcoma, NOS
-      - Liver cell adenoma 
-      - Liver cell carcinoma 
-      - Lobular adenocarcinoma 
-      - Lobular and ductal carcinoma 
-      - Lobular carcinoma in situ, NOS 
-      - Lobular carcinoma, noninfiltrating 
-      - Lobular carcinoma, NOS 
+      - Liver cell adenoma
+      - Liver cell carcinoma
+      - Lobular adenocarcinoma
+      - Lobular and ductal carcinoma
+      - Lobular carcinoma in situ, NOS
+      - Lobular carcinoma, noninfiltrating
+      - Lobular carcinoma, NOS
       - Localized fibrous tumor
-      - Low grade appendiceal mucinous neoplasm 
-      - Luteinoma 
-      - Luteoma, NOS 
+      - Low grade appendiceal mucinous neoplasm
+      - Luteinoma
+      - Luteoma, NOS
       - Lymphangioendothelial sarcoma
       - Lymphangioendothelioma, malignant
       - Lymphangioendothelioma, NOS
@@ -2713,7 +2727,7 @@ properties:
       - Lymphoid leukemia, NOS
       - Lymphoma, NOS
       - Lymphomatoid granulomatosis
-      - Lymphomatoid papulosis 
+      - Lymphomatoid papulosis
       - Lymphoplasmacyte-rich meningioma
       - Lymphoproliferative disease, NOS
       - Lymphoproliferative disorder, NOS
@@ -2722,16 +2736,16 @@ properties:
       - Lymphosarcoma, NOS [obs]
       - M6A
       - M6B
-      - Macrofollicular adenoma 
-      - Magnocellular nevus 
+      - Macrofollicular adenoma
+      - Magnocellular nevus
       - Malignancy
-      - Malignant chondroid syringoma 
-      - Malignant cystic nephroma 
-      - Malignant eccrine spiradenoma 
+      - Malignant chondroid syringoma
+      - Malignant cystic nephroma
+      - Malignant eccrine spiradenoma
       - Malignant fibrous histiocytoma
       - Malignant giant cell tumor of soft parts
       - Malignant histiocytosis
-      - Malignant hydatidiform mole 
+      - Malignant hydatidiform mole
       - Malignant lymphoma, centroblastic, diffuse
       - Malignant lymphoma, centroblastic, follicular
       - Malignant lymphoma, centroblastic, NOS
@@ -2766,7 +2780,7 @@ properties:
       - Malignant lymphoma, large cell, NOS
       - Malignant lymphoma, large cleaved cell, follicular [obs]
       - Malignant lymphoma, large cleaved cell, NOS [obs]
-      - Malignant lymphoma, lymphoblastic, NOS 
+      - Malignant lymphoma, lymphoblastic, NOS
       - Malignant lymphoma, lymphocytec, nodular, NOS [obs]
       - Malignant lymphoma, lymphocytec, poorly differentiated, nodular [obs]
       - Malignant lymphoma, lymphocytec, well differentiated, nodular [obs]
@@ -2776,14 +2790,14 @@ properties:
       - Malignant lymphoma, lymphocytic, NOS
       - Malignant lymphoma, lymphocytic, poorly differentiated, diffuse [obs]
       - Malignant lymphoma, lymphocytic, well differentiated, diffuse
-      - Malignant lymphoma, lymphoplasmacytic 
+      - Malignant lymphoma, lymphoplasmacytic
       - Malignant lymphoma, lymphoplasmacytoid
       - Malignant lymphoma, mixed cell type, diffuse [obs]
       - Malignant lymphoma, mixed cell type, follicular [obs]
       - Malignant lymphoma, mixed cell type, nodular [obs]
       - Malignant lymphoma, mixed lymphocytec-histiocytic, nodular [obs]
       - Malignant lymphoma, mixed lymphocytic-histiocytic, diffuse [obs]
-      - Malignant lymphoma, mixed small and large cell, diffuse 
+      - Malignant lymphoma, mixed small and large cell, diffuse
       - Malignant lymphoma, mixed small cleaved and large cell, follicular [obs]
       - Malignant lymphoma, nodular, NOS [obs]
       - Malignant lymphoma, non-cleaved cell, NOS
@@ -2793,7 +2807,7 @@ properties:
       - Malignant lymphoma, noncleaved, NOS
       - Malignant lymphoma, NOS
       - Malignant lymphoma, plasmacytoid [obs]
-      - Malignant lymphoma, small B lymphocytic, NOS 
+      - Malignant lymphoma, small B lymphocytic, NOS
       - Malignant lymphoma, small cell diffuse
       - Malignant lymphoma, small cell, noncleaved, diffuse [obs]
       - Malignant lymphoma, small cell, NOS
@@ -2810,17 +2824,17 @@ properties:
       - Malignant mast cell tumor
       - Malignant mastocytoma
       - Malignant mastocytosis
-      - Malignant melanoma in congenital melanocytic nevus 
-      - Malignant melanoma in giant pigmented nevus 
-      - Malignant melanoma in Hutchinson melanotic freckle 
-      - Malignant melanoma in junctional nevus 
-      - Malignant melanoma in precancerous melanosis 
+      - Malignant melanoma in congenital melanocytic nevus
+      - Malignant melanoma in giant pigmented nevus
+      - Malignant melanoma in Hutchinson melanotic freckle
+      - Malignant melanoma in junctional nevus
+      - Malignant melanoma in precancerous melanosis
       - Malignant melanoma, NOS (except juvenile melanoma)
-      - Malignant melanoma, regressing 
+      - Malignant melanoma, regressing
       - Malignant midline reticulosis [obs]
       - Malignant mucinous adenofibroma
       - Malignant mucinous cystadenofibroma
-      - Malignant multilocular cystic nephroma 
+      - Malignant multilocular cystic nephroma
       - Malignant myelosclerosis [obs]
       - Malignant myoepithelioma
       - Malignant peripheral nerve sheath tumor
@@ -2831,7 +2845,7 @@ properties:
       - Malignant schwannoma, NOS [obs]
       - Malignant serous adenofibroma
       - Malignant serous cystadenofibroma
-      - Malignant tenosynovial giant cell tumor 
+      - Malignant tenosynovial giant cell tumor
       - Malignant teratoma, anaplastic
       - Malignant teratoma, intermediate
       - Malignant teratoma, trophoblastic
@@ -2847,46 +2861,46 @@ properties:
       - Mantle zone lymphoma [obs]
       - Marginal zone B-cell lymphoma, NOS
       - Marginal zone lymphoma, NOS
-      - Masculinovoblastoma 
-      - Mast cell leukaemia 
+      - Masculinovoblastoma
+      - Mast cell leukaemia
       - Mast cell sarcoma
       - Mast cell tumor, NOS
       - Mastocytoma, NOS
-      - Matrical carcinoma 
+      - Matrical carcinoma
       - Mature T ALL
       - Mature T-cell lymphoma, NOS
       - Mature teratoma
       - Mediastinal (thymic) large B-cell lymphoma)
       - Mediterranean lymphoma
       - Medullary adenocarcinoma
-      - Medullary carcinoma with amyloid stroma 
+      - Medullary carcinoma with amyloid stroma
       - Medullary carcinoma with lymphoid stroma
       - Medullary carcinoma, NOS
-      - Medullary osteosarcoma 
+      - Medullary osteosarcoma
       - Medulloblastoma with extensive nodularity
-      - Medulloblastoma, NOS 
-      - Medullocytoma 
-      - Medulloepithelioma, benign 
+      - Medulloblastoma, NOS
+      - Medullocytoma
+      - Medulloepithelioma, benign
       - Medulloepithelioma, NOS
-      - Medullomyoblastoma 
+      - Medullomyoblastoma
       - Megakaryocytic leukemia
       - Megakaryocytic myelosclerosis
       - Melanoameloblastoma
-      - Melanocytic nevus 
-      - Melanocytoma, eyeball 
+      - Melanocytic nevus
+      - Melanocytoma, eyeball
       - Melanocytoma, NOS
       - Melanoma in situ
-      - Melanoma, malignant, of soft parts 
+      - Melanoma, malignant, of soft parts
       - Melanoma, NOS
-      - Melanotic medulloblastoma 
+      - Melanotic medulloblastoma
       - Melanotic MPNST
       - Melanotic neuroectodermal tumor
       - Melanotic neurofibroma
       - Melanotic progonoma
       - Melanotic psammomatous MPNST
       - Melanotic schwannoma
-      - Meningeal melanocytoma 
-      - Meningeal melanomatosis 
+      - Meningeal melanocytoma
+      - Meningeal melanomatosis
       - Meningeal sarcoma
       - Meningeal sarcomatosis
       - Meningioma, anaplastic
@@ -2895,14 +2909,14 @@ properties:
       - Meningiomatosis, NOS
       - Meningothelial meningioma
       - Meningothelial sarcoma
-      - Merkel cell carcinoma 
-      - Merkel cell tumor 
+      - Merkel cell carcinoma
+      - Merkel cell tumor
       - Mesenchymal chondrosarcoma
       - Mesenchymal tumor, malignant
       - Mesenchymoma, benign
       - Mesenchymoma, malignant
       - Mesenchymoma, NOS
-      - Mesenteric fibromatosis 
+      - Mesenteric fibromatosis
       - Mesoblastic nephroma
       - Mesodermal mixed tumor
       - Mesonephric adenocarcinoma
@@ -2917,63 +2931,63 @@ properties:
       - Mesothelioma, biphasic, NOS
       - Mesothelioma, malignant
       - Mesothelioma, NOS
-      - Metanephric adenoma 
+      - Metanephric adenoma
       - Metaplastic carcinoma, NOS
       - Metaplastic meningioma
       - Metastasizing leiomyoma
       - Metastatic signet ring cell carcinoma
-      - Metatypical carcinoma 
+      - Metatypical carcinoma
       - MGUS
-      - Microcystic adenoma 
-      - Microcystic adnexal carcinoma 
+      - Microcystic adenoma
+      - Microcystic adnexal carcinoma
       - Microcystic meningioma
-      - Microfollicular adenoma, NOS 
-      - Microglioma 
-      - Micropapillary carcinoma, NOS 
-      - Micropapillary serous carcinoma 
-      - Mixed acidophil-basophil adenoma 
-      - Mixed acidophil-basophil carcinoma 
+      - Microfollicular adenoma, NOS
+      - Microglioma
+      - Micropapillary carcinoma, NOS
+      - Micropapillary serous carcinoma
+      - Mixed acidophil-basophil adenoma
+      - Mixed acidophil-basophil carcinoma
       - Mixed acinar-ductal carcinoma
-      - Mixed acinar-endocrine carcinoma 
+      - Mixed acinar-endocrine carcinoma
       - Mixed acinar-endocrine-ductal carcinoma
       - Mixed adenocarcinoma and epidermoid carcinoma
       - Mixed adenocarcinoma and squamous cell carcinoma
-      - Mixed adenomatous and hyperplastic polyp 
+      - Mixed adenomatous and hyperplastic polyp
       - Mixed adenoneuroendocrine carcinoma
-      - Mixed basal-squamous cell carcinoma 
+      - Mixed basal-squamous cell carcinoma
       - Mixed carcinoid-adenocarcinoma
       - Mixed cell adenocarcinoma
       - Mixed cell adenoma
-      - Mixed ductal-endocrine carcinoma 
+      - Mixed ductal-endocrine carcinoma
       - Mixed embryonal carcinoma and teratoma
       - Mixed embryonal rhabdomyosarcoma and alveolar rhabdomyosarcoma
-      - Mixed endocrine and exocrine adenocarcinoma 
+      - Mixed endocrine and exocrine adenocarcinoma
       - Mixed epithelioid and spindle cell melanoma
       - Mixed germ cell tumor
-      - Mixed glioma 
-      - Mixed hepatocellular and bile duct carcinoma 
-      - Mixed islet cell and exocrine adenocarcinoma 
+      - Mixed glioma
+      - Mixed hepatocellular and bile duct carcinoma
+      - Mixed islet cell and exocrine adenocarcinoma
       - Mixed liposarcoma
-      - Mixed medullary-follicular carcinoma 
-      - Mixed medullary-papillary carcinoma 
+      - Mixed medullary-follicular carcinoma
+      - Mixed medullary-papillary carcinoma
       - Mixed meningioma
       - Mixed mesenchymal sarcoma
       - Mixed mesenchymal tumor
-      - Mixed pancreatic endocrine and exocrine tumor, malignant 
+      - Mixed pancreatic endocrine and exocrine tumor, malignant
       - Mixed phenotype acute leukemia with t (9;22) (q34;q11.2); BCR-ABL1
       - Mixed phenotype acute leukemia with t(v;11q23); MLL rearranged
       - Mixed phenotype acute leukemia, B/myeloid, NOS
       - Mixed phenotype acute leukemia, T/myeloid, NOS
-      - Mixed pineal tumor 
-      - Mixed pineocytoma-pineoblastoma 
+      - Mixed pineal tumor
+      - Mixed pineocytoma-pineoblastoma
       - Mixed small cell carcinoma
       - Mixed squamous cell and glandular papilloma
-      - Mixed subependymoma-ependymoma 
+      - Mixed subependymoma-ependymoma
       - Mixed teratoma and seminoma
       - Mixed tumor, malignant, NOS
       - Mixed tumor, NOS
-      - Mixed tumor, salivary gland type, malignant 
-      - Mixed tumor, salivary gland type, NOS 
+      - Mixed tumor, salivary gland type, malignant
+      - Mixed tumor, salivary gland type, NOS
       - Mixed type rhabdomyosarcoma
       - Monoblastic leukemia, Nos
       - Monoclonal gammopathy of undetermined significance
@@ -2981,7 +2995,7 @@ properties:
       - Monocytic leukemia, NOS
       - Monocytoid B-cell lymphoma
       - Monomorphic adenoma
-      - Monstrocellular sarcoma 
+      - Monstrocellular sarcoma
       - MPNST with glandular differentiation
       - MPNST with mesenchymal differentiation
       - MPNST with rhabdomyoblastic differentiation
@@ -3000,49 +3014,49 @@ properties:
       - Mucinous carcinoid
       - Mucinous carcinoma
       - Mucinous cystadenocarcinofibroma
-      - Mucinous cystadenocarcinoma, non-invasive 
-      - Mucinous cystadenocarcinoma, NOS 
+      - Mucinous cystadenocarcinoma, non-invasive
+      - Mucinous cystadenocarcinoma, NOS
       - Mucinous cystadenofibroma of borderline malignancy
       - Mucinous cystadenofibroma, NOS
-      - Mucinous cystadenoma, borderline malignancy 
-      - Mucinous cystadenoma, NOS 
-      - Mucinous cystic neoplasm with an associated invasive carcinoma 
-      - Mucinous cystic neoplasm with high-grade dysplasia 
-      - Mucinous cystic neoplasm with high-grade intraepithelial neoplasia 
-      - Mucinous cystic neoplasm with intermediate-grade dysplasia 
-      - Mucinous cystic neoplasm with intermediate-grade intraepithelial neoplasia 
-      - Mucinous cystic neoplasm with low-grade dysplasia 
-      - Mucinous cystic neoplasm with low-grade intraepithelial neoplasia 
-      - Mucinous cystic tumor of borderline malignancy 
-      - Mucinous cystic tumor with an associated invasive carcinoma 
-      - Mucinous cystic tumor with high-grade dysplasia 
-      - Mucinous cystic tumor with intermediate dysplasia 
-      - Mucinous cystic tumor with low grade dysplasia 
-      - Mucinous cystic tumor with moderate dysplasia 
-      - Mucinous cystoma 
-      - Mucinous tumor, NOS, of low malignant potential 
+      - Mucinous cystadenoma, borderline malignancy
+      - Mucinous cystadenoma, NOS
+      - Mucinous cystic neoplasm with an associated invasive carcinoma
+      - Mucinous cystic neoplasm with high-grade dysplasia
+      - Mucinous cystic neoplasm with high-grade intraepithelial neoplasia
+      - Mucinous cystic neoplasm with intermediate-grade dysplasia
+      - Mucinous cystic neoplasm with intermediate-grade intraepithelial neoplasia
+      - Mucinous cystic neoplasm with low-grade dysplasia
+      - Mucinous cystic neoplasm with low-grade intraepithelial neoplasia
+      - Mucinous cystic tumor of borderline malignancy
+      - Mucinous cystic tumor with an associated invasive carcinoma
+      - Mucinous cystic tumor with high-grade dysplasia
+      - Mucinous cystic tumor with intermediate dysplasia
+      - Mucinous cystic tumor with low grade dysplasia
+      - Mucinous cystic tumor with moderate dysplasia
+      - Mucinous cystoma
+      - Mucinous tumor, NOS, of low malignant potential
       - Mucocarcinoid tumor
       - Mucoepidermoid carcinoma
       - Mucoepidermoid tumor [obs]
       - Mucoid adenocarcinoma
       - Mucoid carcinoma
-      - Mucoid cell adenocarcinoma 
-      - Mucoid cell adenoma 
+      - Mucoid cell adenocarcinoma
+      - Mucoid cell adenoma
       - Mucosal lentiginous melanoma
       - Mucosal-associated lymphoid tissue lymphoma
       - Mucous adenocarcinoma
       - Mucous carcinoma
-      - Mullerian mixed tumor 
-      - Multicentric basal cell carcinoma 
+      - Mullerian mixed tumor
+      - Multicentric basal cell carcinoma
       - Multicystic mesothelioma, benign
-      - Multifocal superficial basal cell carcinoma 
+      - Multifocal superficial basal cell carcinoma
       - Multiple adenomatous polyps
       - Multiple endocrine adenomas
       - Multiple hemorrhagic sarcoma
       - Multiple meningiomas
-      - Multiple myeloma 
+      - Multiple myeloma
       - Multiple neurofibromatosis
-      - Mycosis fungoides 
+      - Mycosis fungoides
       - Myelocytic leukemia, NOS
       - Myelodysplastic syndrome with 5q deletion (5q-) syndrome
       - Myelodysplastic syndrome with isolated del (5q)
@@ -3057,10 +3071,10 @@ properties:
       - Myeloid leukemia associated with Down Syndrome
       - Myeloid leukemia, NOS
       - Myeloid neoplasms with PDGFRB rearrangement
-      - Myeloid sarcoma 
+      - Myeloid sarcoma
       - Myelolipoma
-      - Myeloma, NOS 
-      - Myelomatosis 
+      - Myeloma, NOS
+      - Myelomatosis
       - Myelomonocytic leukemia, NOS
       - Myeloproliferative disease, NOS
       - Myeloproliferative neoplasm, NOS
@@ -3071,7 +3085,7 @@ properties:
       - Myoepithelial tumor
       - Myoepithelioma
       - Myofibroblastic tumor, NOS
-      - Myofibroblastic tumor, peribronchial 
+      - Myofibroblastic tumor, peribronchial
       - Myofibroblastoma
       - Myofibroma
       - Myofibromatosis
@@ -3085,7 +3099,7 @@ properties:
       - Myxolipoma
       - Myxoliposarcoma
       - Myxoma, NOS
-      - Myxopapillary ependymoma 
+      - Myxopapillary ependymoma
       - Myxosarcoma
       - Neoplasm, benign
       - Neoplasm, malignant
@@ -3094,11 +3108,11 @@ properties:
       - Neoplasm, NOS
       - Neoplasm, secondary
       - Neoplasm, uncertain whether benign or malignant
-      - Nephroblastoma, NOS 
-      - Nephrogenic adenofibroma 
-      - Nephroma, NOS 
+      - Nephroblastoma, NOS
+      - Nephrogenic adenofibroma
+      - Nephroma, NOS
       - Nerve sheath myxoma
-      - Nesidioblastoma 
+      - Nesidioblastoma
       - Neurilemoma, malignant [obs]
       - Neurilemoma, NOS
       - Neurilemosarcoma [obs]
@@ -3119,37 +3133,37 @@ properties:
       - Neurofibromatosis, NOS
       - Neurofibrosarcoma [obs]
       - Neurogenic sarcoma [obs]
-      - Neurolipocytoma 
+      - Neurolipocytoma
       - Neuroma, NOS
-      - Neuronevus 
+      - Neuronevus
       - Neurosarcoma [obs]
       - Neurothekeoma
-      - Neurotropic melanoma, malignant 
-      - Nevus, NOS 
+      - Neurotropic melanoma, malignant
+      - Nevus, NOS
       - NK-cell large granular lymphocytic leukemia
       - NK/T-cell lymphoma, nasal and nasal-type
       - Nodal marginal zone lymphoma
-      - Nodular hidradenoma 
-      - Nodular hidradenoma, malignant 
-      - Nodular melanoma 
+      - Nodular hidradenoma
+      - Nodular hidradenoma, malignant
+      - Nodular melanoma
       - Non-Hodgkin lymphoma, NOS
       - Non-lymphocytic leukemia, NOS
-      - Non-small cell carcinoma 
+      - Non-small cell carcinoma
       - Nonchromaffin paraganglioma, malignant
       - Nonchromaffin paraganglioma, NOS
-      - Nonencapsulated sclerosing adenocarcinoma 
-      - Nonencapsulated sclerosing carcinoma 
-      - Nonencapsulated sclerosing tumor 
+      - Nonencapsulated sclerosing adenocarcinoma
+      - Nonencapsulated sclerosing carcinoma
+      - Nonencapsulated sclerosing tumor
       - Noninfiltrating intracystic carcinoma
-      - Noninfiltrating intraductal papillary adenocarcinoma 
-      - Noninfiltrating intraductal papillary carcinoma 
-      - Noninvasive pancreatobiliary papillary neoplasm with high grade dysplasia 
-      - Noninvasive pancreatobiliary papillary neoplasm with high grade intraepithelial neoplasia 
+      - Noninfiltrating intraductal papillary adenocarcinoma
+      - Noninfiltrating intraductal papillary carcinoma
+      - Noninvasive pancreatobiliary papillary neoplasm with high grade dysplasia
+      - Noninvasive pancreatobiliary papillary neoplasm with high grade intraepithelial neoplasia
       - Noninvasive pancreatobiliary papillary neoplasm with low grade dysplasia
       - Noninvasive pancreatobiliary papillary neoplasm with low grade intraepithelial neoplasia
-      - Nonlipid reticuloendotheliosis 
-      - Nonpigmented nevus 
-      - Oat cell carcinoma 
+      - Nonlipid reticuloendotheliosis
+      - Nonpigmented nevus
+      - Oat cell carcinoma
       - Odontoameloblastoma
       - Odontogenic carcinoma
       - Odontogenic carcinosarcoma
@@ -3163,108 +3177,108 @@ properties:
       - Odontogenic tumor, malignant
       - Odontogenic tumor, NOS
       - Odontoma, NOS
-      - Olfactory neuroblastoma 
-      - Olfactory neurocytoma 
-      - Olfactory neuroepithelioma 
+      - Olfactory neuroblastoma
+      - Olfactory neurocytoma
+      - Olfactory neuroepithelioma
       - Olfactory neurogenic tumor
-      - Oligoastrocytoma 
-      - Oligodendroblastoma 
-      - Oligodendroglioma, anaplastic 
-      - Oligodendroglioma, NOS 
+      - Oligoastrocytoma
+      - Oligodendroblastoma
+      - Oligodendroglioma, anaplastic
+      - Oligodendroglioma, NOS
       - Oncocytic adenocarcinoma
       - Oncocytic adenoma
       - Oncocytic carcinoma
-      - Oncocytic Schneiderian papilloma 
+      - Oncocytic Schneiderian papilloma
       - Oncocytoma
-      - Orchioblastoma 
+      - Orchioblastoma
       - Ossifying fibroma
       - Ossifying fibromyxoid tumor
-      - Ossifying renal tumor 
-      - Osteoblastic sarcoma 
-      - Osteoblastoma, malignant 
-      - Osteoblastoma, NOS 
-      - Osteocartilaginous exostosis 
-      - Osteochondroma 
-      - Osteochondromatosis, NOS 
-      - Osteochondrosarcoma 
+      - Ossifying renal tumor
+      - Osteoblastic sarcoma
+      - Osteoblastoma, malignant
+      - Osteoblastoma, NOS
+      - Osteocartilaginous exostosis
+      - Osteochondroma
+      - Osteochondromatosis, NOS
+      - Osteochondrosarcoma
       - Osteofibroma
-      - Osteofibrosarcoma 
-      - Osteogenic sarcoma, NOS 
-      - Osteoid osteoma, NOS 
-      - Osteoma, NOS 
-      - Osteosarcoma in Paget disease of bone 
-      - Osteosarcoma, NOS 
-      - Ovarian stromal tumor 
+      - Osteofibrosarcoma
+      - Osteogenic sarcoma, NOS
+      - Osteoid osteoma, NOS
+      - Osteoma, NOS
+      - Osteosarcoma in Paget disease of bone
+      - Osteosarcoma, NOS
+      - Ovarian stromal tumor
       - Oxyphilic adenocarcinoma
       - Oxyphilic adenoma
       - Pacinian tumor
-      - Paget disease and infiltrating duct carcinoma of breast 
-      - Paget disease and intraductal carcinoma of breast 
-      - Paget disease of breast 
+      - Paget disease and infiltrating duct carcinoma of breast
+      - Paget disease and intraductal carcinoma of breast
+      - Paget disease of breast
       - Paget disease, extramammary (except Paget disease of bone)
-      - Paget disease, mammary 
+      - Paget disease, mammary
       - Pagetoid reticulosis
-      - Pancreatic endocrine tumor, benign 
+      - Pancreatic endocrine tumor, benign
       - Pancreatic endocrine tumor, malignant
       - Pancreatic endocrine tumor, nonfunctioning
-      - Pancreatic endocrine tumor, NOS 
-      - Pancreatic microadenoma 
+      - Pancreatic endocrine tumor, NOS
+      - Pancreatic microadenoma
       - Pancreatic peptide and pancreatic peptide-like peptide within terminal tyrosine amide producing tumor
       - Pancreatobiliary neoplasm, non-invasive
-      - Pancreatobiliary-type carcinoma 
-      - Pancreatoblastoma 
-      - Papillary adenocarcinoma, follicular variant 
+      - Pancreatobiliary-type carcinoma
+      - Pancreatoblastoma
+      - Papillary adenocarcinoma, follicular variant
       - Papillary adenocarcinoma, NOS
       - Papillary adenofibroma
       - Papillary adenoma, NOS
-      - Papillary and follicular adenocarcinoma 
-      - Papillary and follicular carcinoma 
+      - Papillary and follicular adenocarcinoma
+      - Papillary and follicular carcinoma
       - Papillary carcinoma in situ
-      - Papillary carcinoma of thyroid 
-      - Papillary carcinoma, columnar cell 
-      - Papillary carcinoma, diffuse sclerosing 
-      - Papillary carcinoma, encapsulated 
-      - Papillary carcinoma, follicular variant 
+      - Papillary carcinoma of thyroid
+      - Papillary carcinoma, columnar cell
+      - Papillary carcinoma, diffuse sclerosing
+      - Papillary carcinoma, encapsulated
+      - Papillary carcinoma, follicular variant
       - Papillary carcinoma, NOS
-      - Papillary carcinoma, oxyphilic cell 
-      - Papillary carcinoma, tall cell 
-      - Papillary cystadenocarcinoma, NOS 
-      - Papillary cystadenoma lymphomatosum 
-      - Papillary cystadenoma, borderline malignancy 
-      - Papillary cystadenoma, NOS 
-      - Papillary cystic tumor 
-      - Papillary ependymoma 
+      - Papillary carcinoma, oxyphilic cell
+      - Papillary carcinoma, tall cell
+      - Papillary cystadenocarcinoma, NOS
+      - Papillary cystadenoma lymphomatosum
+      - Papillary cystadenoma, borderline malignancy
+      - Papillary cystadenoma, NOS
+      - Papillary cystic tumor
+      - Papillary ependymoma
       - Papillary epidermoid carcinoma
       - Papillary glioneuronal tumor
       - Papillary hidradenoma
       - Papillary meningioma
-      - Papillary microcarcinoma 
-      - Papillary mucinous cystadenocarcinoma 
-      - Papillary mucinous cystadenoma, borderline malignancy 
-      - Papillary mucinous cystadenoma, NOS 
-      - Papillary mucinous tumor of low malignant potential 
-      - Papillary neoplasm, pancreatobiliary-type, with high grade intraepithelial neoplasia 
-      - Papillary pseudomucinous cystadenocarcinoma 
-      - Papillary pseudomucinous cystadenoma, borderline malignancy 
-      - Papillary pseudomucinous cystadenoma, NOS 
-      - Papillary renal cell carcinoma 
-      - Papillary serous adenocarcinoma 
-      - Papillary serous cystadenocarcinoma 
-      - Papillary serous cystadenoma, borderline malignancy 
-      - Papillary serous cystadenoma, NOS 
-      - Papillary serous tumor of low malignant potential 
+      - Papillary microcarcinoma
+      - Papillary mucinous cystadenocarcinoma
+      - Papillary mucinous cystadenoma, borderline malignancy
+      - Papillary mucinous cystadenoma, NOS
+      - Papillary mucinous tumor of low malignant potential
+      - Papillary neoplasm, pancreatobiliary-type, with high grade intraepithelial neoplasia
+      - Papillary pseudomucinous cystadenocarcinoma
+      - Papillary pseudomucinous cystadenoma, borderline malignancy
+      - Papillary pseudomucinous cystadenoma, NOS
+      - Papillary renal cell carcinoma
+      - Papillary serous adenocarcinoma
+      - Papillary serous cystadenocarcinoma
+      - Papillary serous cystadenoma, borderline malignancy
+      - Papillary serous cystadenoma, NOS
+      - Papillary serous tumor of low malignant potential
       - Papillary squamous cell carcinoma
       - Papillary squamous cell carcinoma in situ
       - Papillary squamous cell carcinoma, non-invasive
-      - Papillary syringadenoma 
-      - Papillary syringocystadenoma 
-      - Papillary transitional cell carcinoma 
-      - Papillary transitional cell carcinoma, non-invasive 
-      - Papillary transitional cell neoplasm of low malignant potential 
+      - Papillary syringadenoma
+      - Papillary syringocystadenoma
+      - Papillary transitional cell carcinoma
+      - Papillary transitional cell carcinoma, non-invasive
+      - Papillary transitional cell neoplasm of low malignant potential
       - Papillary tumor of the pineal region
-      - Papillary urothelial carcinoma 
-      - Papillary urothelial carcinoma, non-invasive 
-      - Papillary urothelial neoplasm of low malignant potential 
+      - Papillary urothelial carcinoma
+      - Papillary urothelial carcinoma, non-invasive
+      - Papillary urothelial neoplasm of low malignant potential
       - Papillocystic adenocarcinoma
       - Papilloma of bladder
       - Papilloma, NOS (except papilloma of bladder M-8120/I)
@@ -3273,28 +3287,28 @@ properties:
       - Papillotubular adenocarcinoma
       - Papillotubular adenoma
       - Parachordoma
-      - Parafollicular cell carcinoma 
+      - Parafollicular cell carcinoma
       - Paraganglioma, benign
       - Paraganglioma, malignant
       - Paraganglioma, NOS
       - Parasympathetic paraganglioma
-      - Parietal cell adenocarcinoma 
-      - Parietal cell carcinoma 
-      - Parosteal osteosarcoma 
-      - Partial hydatidiform mole 
+      - Parietal cell adenocarcinoma
+      - Parietal cell carcinoma
+      - Parosteal osteosarcoma
+      - Partial hydatidiform mole
       - Periapical cemental dysplasia
       - Periapical cemento-osseous dysplasia
-      - Pericanalicular fibroadenoma 
-      - Perifollicular fibroma 
+      - Pericanalicular fibroadenoma
+      - Perifollicular fibroma
       - Perineural MPNST
       - Perineurioma, malignant
       - Perineurioma, NOS
-      - Periosteal chondroma 
-      - Periosteal chondrosarcoma 
-      - Periosteal fibroma 
-      - Periosteal fibrosarcoma 
-      - Periosteal osteosarcoma 
-      - Periosteal sarcoma, NOS 
+      - Periosteal chondroma
+      - Periosteal chondrosarcoma
+      - Periosteal fibroma
+      - Periosteal fibrosarcoma
+      - Periosteal osteosarcoma
+      - Periosteal sarcoma, NOS
       - Peripheral neuroectodermal tumor
       - Peripheral odontogenic fibroma
       - Peripheral primitive neuroectodermal tumor, NOS
@@ -3303,47 +3317,47 @@ properties:
       - Peripheral T-cell lymphoma, NOS
       - Peripheral T-cell lymphoma, pleomorphic medium and large cell
       - Peripheral T-cell lymphoma, pleomorphic small cell
-      - Pheochromoblastoma 
-      - Pheochromocytoma, malignant 
-      - Pheochromocytoma, NOS 
-      - Phyllodes tumor, benign 
-      - Phyllodes tumor, borderline 
-      - Phyllodes tumor, malignant 
-      - Phyllodes tumor, NOS 
+      - Pheochromoblastoma
+      - Pheochromocytoma, malignant
+      - Pheochromocytoma, NOS
+      - Phyllodes tumor, benign
+      - Phyllodes tumor, borderline
+      - Phyllodes tumor, malignant
+      - Phyllodes tumor, NOS
       - Pick tubular adenoma
-      - Pigmented adenoma 
-      - Pigmented basal cell carcinoma 
-      - Pigmented dermatofibrosarcoma protuberans 
-      - Pigmented nevus, NOS 
+      - Pigmented adenoma
+      - Pigmented basal cell carcinoma
+      - Pigmented dermatofibrosarcoma protuberans
+      - Pigmented nevus, NOS
       - Pigmented schwannoma
-      - Pigmented spindle cell nevus of Reed 
-      - Pilar tumor 
-      - Pilocytic astrocytoma 
-      - Piloid astrocytoma 
-      - Pilomatricoma, malignant 
-      - Pilomatricoma, NOS 
-      - Pilomatrix carcinoma 
-      - Pilomatrixoma, malignant 
-      - Pilomatrixoma, NOS 
+      - Pigmented spindle cell nevus of Reed
+      - Pilar tumor
+      - Pilocytic astrocytoma
+      - Piloid astrocytoma
+      - Pilomatricoma, malignant
+      - Pilomatricoma, NOS
+      - Pilomatrix carcinoma
+      - Pilomatrixoma, malignant
+      - Pilomatrixoma, NOS
       - Pilomyxoid astrocytoma
-      - PIN III 
+      - PIN III
       - Pindborg tumor
-      - Pineal parenchymal tumor of intermediate differentiation 
-      - Pinealoma 
-      - Pineoblastoma 
-      - Pineocytoma 
+      - Pineal parenchymal tumor of intermediate differentiation
+      - Pinealoma
+      - Pineoblastoma
+      - Pineocytoma
       - Pinkus tumor
       - Pituicytoma
-      - Pituitary adenoma, NOS 
-      - Pituitary carcinoma, NOS 
-      - Placental site trophoblastic tumor 
-      - Plasma cell leukemia 
-      - Plasma cell myeloma 
+      - Pituitary adenoma, NOS
+      - Pituitary carcinoma, NOS
+      - Placental site trophoblastic tumor
+      - Plasma cell leukemia
+      - Plasma cell myeloma
       - Plasma cell tumor
       - Plasmablastic lymphoma
-      - Plasmacytic leukemia 
+      - Plasmacytic leukemia
       - Plasmacytic lymphoma [obs]
-      - Plasmacytoma of bone 
+      - Plasmacytoma of bone
       - Plasmacytoma, extramedullary (not occurring in bone)
       - Plasmacytoma, NOS
       - Pleomorphic adenoma
@@ -3354,7 +3368,7 @@ properties:
       - Pleomorphic liposarcoma
       - Pleomorphic rhabdomyosarcoma, adult type
       - Pleomorphic rhabdomyosarcoma, NOS
-      - Pleomorphic xanthoastrocytoma 
+      - Pleomorphic xanthoastrocytoma
       - Pleuropulmonary blastoma
       - Plexiform fibrohistiocytic tumor
       - Plexiform fibromyxoma
@@ -3364,8 +3378,8 @@ properties:
       - Plexiform neuroma
       - Plexiform schwannoma
       - PNET, NOS
-      - Pneumoblastoma 
-      - Polar spongioblastoma 
+      - Pneumoblastoma
+      - Polar spongioblastoma
       - Polycythemia rubra vera
       - Polycythemia vera
       - Polyembryoma
@@ -3376,72 +3390,72 @@ properties:
       - Polypoid adenoma
       - Polyvesicular vitelline tumor
       - Poorly cohesive carcinoma
-      - Porocarcinoma 
+      - Porocarcinoma
       - Post transplant lymphoproliferative disorder, NOS
       - PP/PYY producing tumor
       - PPNET
       - Pre-B ALL
       - Pre-pre-B ALL
       - Pre-T ALL
-      - Precancerous melanosis, NOS 
-      - Precursor B-cell lymphoblastic leukemia 
-      - Precursor B-cell lymphoblastic lymphoma 
-      - Precursor cell lymphoblastic leukemia, NOS 
+      - Precancerous melanosis, NOS
+      - Precursor B-cell lymphoblastic leukemia
+      - Precursor B-cell lymphoblastic lymphoma
+      - Precursor cell lymphoblastic leukemia, NOS
       - Precursor cell lymphoblastic leukemia, not phenotyped
-      - Precursor cell lymphoblastic lymphoma, NOS 
-      - Precursor T-cell lymphoblastic leukemia 
-      - Precursor T-cell lymphoblastic lymphoma 
+      - Precursor cell lymphoblastic lymphoma, NOS
+      - Precursor T-cell lymphoblastic leukemia
+      - Precursor T-cell lymphoblastic lymphoma
       - Preleukaemia [obs]
       - Preleukemic syndrome [obs]
       - Primary amyloidosis
-      - Primary cutaneous anaplastic large cell lymphoma 
-      - Primary cutaneous CD30+ large T-cell lymphoma 
-      - Primary cutaneous CD30+ T-cell lymphoproliferative disorder 
+      - Primary cutaneous anaplastic large cell lymphoma
+      - Primary cutaneous CD30+ large T-cell lymphoma
+      - Primary cutaneous CD30+ T-cell lymphoproliferative disorder
       - Primary cutaneous CD4-positive small/medium T-cell lymphoma
       - Primary cutaneous CD8-positive aggressive epidermotropic cytotoxic T-cell lymphoma
-      - Primary cutaneous DLBCL, leg type 
+      - Primary cutaneous DLBCL, leg type
       - Primary cutaneous follicle centre lymphoma
       - Primary cutaneous gamma-delta T-cell lymphoma
-      - Primary cutaneous neuroendocrine carcinoma 
-      - Primary diffuse large B-cell lymphoma of the CNS 
+      - Primary cutaneous neuroendocrine carcinoma
+      - Primary diffuse large B-cell lymphoma of the CNS
       - Primary effusion lymphoma
       - Primary intraosseous carcinoma
       - Primary myelofibrosis
-      - Primary serous papillary carcinoma of peritoneum 
+      - Primary serous papillary carcinoma of peritoneum
       - Primitive neuroectodermal tumor, NOS
-      - Primitive polar spongioblastoma 
+      - Primitive polar spongioblastoma
       - Pro-B ALL
       - Pro-T ALL
-      - Prolactinoma 
+      - Prolactinoma
       - Proliferating trichilemmal cyst
       - Proliferating trichilemmal tumor
-      - Proliferative dermal lesion in congenital nevus 
+      - Proliferative dermal lesion in congenital nevus
       - Proliferative polycythemia
       - Prolymphocytic leukemia, B-cell type
       - Prolymphocytic leukemia, NOS
       - Prolymphocytic leukemia, T-cell type
-      - Prostatic intraepithelial neoplasia, grade III 
-      - Protoplasmic astrocytoma 
+      - Prostatic intraepithelial neoplasia, grade III
+      - Protoplasmic astrocytoma
       - Psammomatous meningioma
       - Psammomatous schwannoma
-      - Pseudomucinous adenocarcinoma 
-      - Pseudomucinous cystadenocarcinoma, NOS 
-      - Pseudomucinous cystadenoma, borderline malignancy 
-      - Pseudomucinous cystadenoma, NOS 
+      - Pseudomucinous adenocarcinoma
+      - Pseudomucinous cystadenocarcinoma, NOS
+      - Pseudomucinous cystadenoma, borderline malignancy
+      - Pseudomucinous cystadenoma, NOS
       - Pseudomyxoma peritonei
-      - Pseudomyxoma peritonei with unknown primary site 
+      - Pseudomyxoma peritonei with unknown primary site
       - Pseudosarcomatous carcinoma
       - PTLD, NOS
-      - Pulmonary adenomatosis 
-      - Pulmonary blastoma 
-      - Queyrat erythroplasia 
+      - Pulmonary adenomatosis
+      - Pulmonary blastoma
+      - Queyrat erythroplasia
       - Racemose hemangioma
       - RAEB
       - RAEB I
       - RAEB II
       - RAEB-T
       - RARS
-      - Rathke pouch tumor 
+      - Rathke pouch tumor
       - Recklinghausen disease (except of bone)
       - Refractory anemia
       - Refractory anemia with excess blasts
@@ -3454,16 +3468,16 @@ properties:
       - Refractory cytopenia with multilineage dysplasia
       - Refractory neutropenia
       - Refractory thrombocytopenia
-      - Regressing nevus 
-      - Renal carcinoma, collecting duct type 
-      - Renal cell adenocarcinoma 
-      - Renal cell carcinoma, chromophobe type 
-      - Renal cell carcinoma, NOS 
-      - Renal cell carcinoma, sarcomatoid 
-      - Renal cell carcinoma, spindle cell 
-      - Reninoma 
-      - Renomedullary fibroma 
-      - Renomedullary interstitial cell tumor 
+      - Regressing nevus
+      - Renal carcinoma, collecting duct type
+      - Renal cell adenocarcinoma
+      - Renal cell carcinoma, chromophobe type
+      - Renal cell carcinoma, NOS
+      - Renal cell carcinoma, sarcomatoid
+      - Renal cell carcinoma, spindle cell
+      - Reninoma
+      - Renomedullary fibroma
+      - Renomedullary interstitial cell tumor
       - Reserve cell carcinoma
       - Reticulohistiocytoma
       - Reticulosarcoma, diffuse [obs]
@@ -3471,13 +3485,13 @@ properties:
       - Reticulum cell sarcoma, diffuse [obs]
       - Reticulum cell sarcoma, NOS [obs]
       - Retinal anlage tumor
-      - Retinoblastoma, differentiated 
-      - Retinoblastoma, diffuse 
-      - Retinoblastoma, NOS 
-      - Retinoblastoma, spontaneously regressed 
-      - Retinoblastoma, undifferentiated 
-      - Retinocytoma 
-      - Retroperitoneal fibromatosis 
+      - Retinoblastoma, differentiated
+      - Retinoblastoma, diffuse
+      - Retinoblastoma, NOS
+      - Retinoblastoma, spontaneously regressed
+      - Retinoblastoma, undifferentiated
+      - Retinocytoma
+      - Retroperitoneal fibromatosis
       - Rhabdoid meningioma
       - Rhabdoid sarcoma
       - Rhabdoid tumor, NOS
@@ -3485,11 +3499,11 @@ properties:
       - Rhabdomyosarcoma with ganglionic differentiation
       - Rhabdomyosarcoma, NOS
       - Rhabdosarcoma
-      - Rodent ulcer 
+      - Rodent ulcer
       - Rosette-forming glioneuronal tumor
       - Round cell carcinoma
       - Round cell liposarcoma
-      - Round cell osteosarcoma 
+      - Round cell osteosarcoma
       - Round cell sarcoma
       - SALT lymphoma
       - Sarcoma botryoides
@@ -3497,28 +3511,28 @@ properties:
       - Sarcomatoid carcinoma
       - Sarcomatoid mesothelioma
       - Sarcomatosis, NOS
-      - Schmincke tumor 
-      - Schneiderian carcinoma 
-      - Schneiderian papilloma, inverted 
-      - Schneiderian papilloma, NOS 
+      - Schmincke tumor
+      - Schneiderian carcinoma
+      - Schneiderian papilloma, inverted
+      - Schneiderian papilloma, NOS
       - Schwannoma, NOS
       - Scirrhous adenocarcinoma
       - Scirrhous carcinoma
-      - Sclerosing hemangioma 
-      - Sclerosing hepatic carcinoma 
+      - Sclerosing hemangioma
+      - Sclerosing hepatic carcinoma
       - Sclerosing liposarcoma
-      - Sclerosing stromal tumor 
-      - Sclerosing sweat duct carcinoma 
-      - Sebaceous adenocarcinoma 
-      - Sebaceous adenoma 
-      - Sebaceous carcinoma 
-      - Sebaceous epithelioma 
+      - Sclerosing stromal tumor
+      - Sclerosing sweat duct carcinoma
+      - Sebaceous adenocarcinoma
+      - Sebaceous adenoma
+      - Sebaceous carcinoma
+      - Sebaceous epithelioma
       - Secondary carcinoma
-      - Secretory carcinoma of breast 
+      - Secretory carcinoma of breast
       - Secretory meningioma
-      - Seminoma with high mitotic index 
-      - Seminoma, anaplastic 
-      - Seminoma, NOS 
+      - Seminoma with high mitotic index
+      - Seminoma, anaplastic
+      - Seminoma, NOS
       - Serotonin producing carcinoid
       - Serous adenocarcinofibroma
       - Serous adenocarcinoma, NOS
@@ -3526,22 +3540,22 @@ properties:
       - Serous adenofibroma, NOS
       - Serous carcinoma, NOS
       - Serous cystadenocarcinofibroma
-      - Serous cystadenocarcinoma, NOS 
+      - Serous cystadenocarcinoma, NOS
       - Serous cystadenofibroma of borderline malignancy
       - Serous cystadenofibroma, NOS
-      - Serous cystadenoma, borderline malignancy 
+      - Serous cystadenoma, borderline malignancy
       - Serous cystadenoma, NOS
       - Serous cystoma
       - Serous microcystic adenoma
-      - Serous papillary cystic tumor of borderline malignancy 
-      - Serous surface papillary carcinoma 
-      - Serous surface papillary tumor of borderline malignancy 
-      - Serous surface papilloma 
-      - Serous tumor, NOS, of low malignant potential 
+      - Serous papillary cystic tumor of borderline malignancy
+      - Serous surface papillary carcinoma
+      - Serous surface papillary tumor of borderline malignancy
+      - Serous surface papilloma
+      - Serous tumor, NOS, of low malignant potential
       - Serrated adenocarcinoma
-      - Serrated adenoma 
+      - Serrated adenoma
       - Sertoli cell adenoma
-      - Sertoli cell carcinoma 
+      - Sertoli cell carcinoma
       - Sertoli cell tumor with lipid storage
       - Sertoli cell tumor, NOS
       - Sertoli-Leydig cell tumor of intermediate differentiation
@@ -3556,7 +3570,7 @@ properties:
       - Sessile serrated adenoma
       - Sessile serrated polyp
       - SETTLE
-      - Sex cord tumor with annular tubules 
+      - Sex cord tumor with annular tubules
       - Sex cord tumor, NOS
       - Sex cord-gonadal stromal tumor, incompletely differentiated
       - Sex cord-gonadal stromal tumor, mixed forms
@@ -3566,20 +3580,20 @@ properties:
       - Sialoblastoma
       - Signet ring cell adenocarcinoma
       - Signet ring cell carcinoma
-      - Sinonasal papilloma, exophytic 
-      - Sinonasal papilloma, fungiform 
-      - Sinonasal papilloma, NOS 
-      - Skin appendage adenoma 
-      - Skin appendage carcinoma 
-      - Skin appendage tumor, benign 
+      - Sinonasal papilloma, exophytic
+      - Sinonasal papilloma, fungiform
+      - Sinonasal papilloma, NOS
+      - Skin appendage adenoma
+      - Skin appendage carcinoma
+      - Skin appendage tumor, benign
       - Skin-associated lymphoid tissue lymphoma
       - Small cell carcinoma, fusiform cell
       - Small cell carcinoma, intermediate cell
       - Small cell carcinoma, NOS
       - Small cell neuroendocrine carcinoma
-      - Small cell osteosarcoma 
+      - Small cell osteosarcoma
       - Small cell sarcoma
-      - Small congenital nevus 
+      - Small congenital nevus
       - Smooth muscle tumor of uncertain malignant potential
       - Smooth muscle tumor, NOS
       - Soft tissue perineurioma
@@ -3587,12 +3601,12 @@ properties:
       - Soft tissue tumor, benign
       - Soft tissue tumor, malignant
       - Solid adenocarcinoma with mucin formation
-      - Solid and cystic tumor 
-      - Solid and papillary epithelial neoplasm 
+      - Solid and cystic tumor
+      - Solid and papillary epithelial neoplasm
       - Solid carcinoma with mucin formation
       - Solid carcinoma, NOS
-      - Solid pseudopapillary carcinoma 
-      - Solid pseudopapillary tumor 
+      - Solid pseudopapillary carcinoma
+      - Solid pseudopapillary tumor
       - Solid teratoma
       - Solitary fibrous tumor
       - Solitary fibrous tumor, malignant
@@ -3603,32 +3617,32 @@ properties:
       - Somatostatin cell tumor, NOS
       - Somatostatinoma, malignant
       - Somatostatinoma, NOS
-      - Spermatocytic seminoma 
-      - Spermatocytoma 
+      - Spermatocytic seminoma
+      - Spermatocytoma
       - Spindle cell angioendothelioma
       - Spindle cell carcinoma, NOS
       - Spindle cell hemangioendothelioma
       - Spindle cell lipoma
       - Spindle cell melanoma, NOS
-      - Spindle cell melanoma, type A 
-      - Spindle cell melanoma, type B 
-      - Spindle cell nevus, NOS 
-      - Spindle cell oncocytoma 
+      - Spindle cell melanoma, type A
+      - Spindle cell melanoma, type B
+      - Spindle cell nevus, NOS
+      - Spindle cell oncocytoma
       - Spindle cell rhabdomyosarcoma
       - Spindle cell sarcoma
       - Spindle epithelial tumor with thymus-like differentiation
       - Spindle epithelial tumor with thymus-like element
       - Spindled mesothelioma
-      - Spiradenoma, NOS 
-      - Spitz nevus 
+      - Spiradenoma, NOS
+      - Spitz nevus
       - Splenic B-cell lymphoma/leukemia, unclassifiable
       - Splenic diffuse red pulp small B-cell lymphoma
-      - Splenic lymphoma with villous lymphocytes 
-      - Splenic marginal zone B-cell lymphoma 
-      - Splenic marginal zone lymphoma, NOS 
-      - Spongioblastoma multiforme 
-      - Spongioblastoma polare 
-      - Spongioblastoma, NOS 
+      - Splenic lymphoma with villous lymphocytes
+      - Splenic marginal zone B-cell lymphoma
+      - Splenic marginal zone lymphoma, NOS
+      - Spongioblastoma multiforme
+      - Spongioblastoma polare
+      - Spongioblastoma, NOS
       - Spongioneuroblastoma
       - Squamous carcinoma
       - Squamous cell carcinoma in situ with questionable stromal invasion
@@ -3662,16 +3676,16 @@ properties:
       - Stem cell leukemia
       - Steroid cell tumor, malignant
       - Steroid cell tumor, NOS
-      - Stromal endometriosis 
-      - Stromal myosis, NOS 
+      - Stromal endometriosis
+      - Stromal myosis, NOS
       - Stromal sarcoma, NOS
-      - Stromal tumor with minor sex cord elements 
+      - Stromal tumor with minor sex cord elements
       - Stromal tumor, benign
       - Stromal tumor, NOS
-      - Struma ovarii and carcinoid 
-      - Struma ovarii, malignant 
-      - Struma ovarii, NOS 
-      - Strumal carcinoid 
+      - Struma ovarii and carcinoid
+      - Struma ovarii, malignant
+      - Struma ovarii, NOS
+      - Strumal carcinoid
       - Subacute granulocytic leukemia [obs]
       - Subacute leukemia, NOS [obs]
       - Subacute lymphatic leukemia [obs]
@@ -3680,23 +3694,23 @@ properties:
       - Subacute monocytic leukemia [obs]
       - Subacute myelogenous leukemia [obs]
       - Subacute myeloid leukemia [obs]
-      - Subareolar duct papillomatosis 
+      - Subareolar duct papillomatosis
       - Subcutaneous panniculitis-like T-cell lymphoma
-      - Subependymal astrocytoma, NOS 
-      - Subependymal giant cell astrocytoma 
-      - Subependymal glioma 
-      - Subependymoma 
-      - Subepidermal nodular fibrosis 
+      - Subependymal astrocytoma, NOS
+      - Subependymal giant cell astrocytoma
+      - Subependymal glioma
+      - Subependymoma
+      - Subepidermal nodular fibrosis
       - Superficial spreading adenocarcinoma
-      - Superficial spreading melanoma 
+      - Superficial spreading melanoma
       - Superficial well differentated liposarcoma
-      - Supratentorial PNET 
-      - Sweat gland adenocarcinoma 
-      - Sweat gland adenoma 
-      - Sweat gland carcinoma 
-      - Sweat gland tumor, benign 
-      - Sweat gland tumor, malignant 
-      - Sweat gland tumor, NOS 
+      - Supratentorial PNET
+      - Sweat gland adenocarcinoma
+      - Sweat gland adenoma
+      - Sweat gland carcinoma
+      - Sweat gland tumor, benign
+      - Sweat gland tumor, malignant
+      - Sweat gland tumor, NOS
       - Sympathetic paraganglioma
       - Sympathicoblastoma
       - Symplastic leiomyoma
@@ -3709,11 +3723,11 @@ properties:
       - Synovioma, benign
       - Synovioma, malignant
       - Synovioma, NOS
-      - Syringadenoma, NOS 
+      - Syringadenoma, NOS
       - Syringocystadenoma papilliferum
-      - Syringofibroadenoma 
-      - Syringoma, NOS 
-      - Syringomatous carcinoma 
+      - Syringofibroadenoma
+      - Syringoma, NOS
+      - Syringomatous carcinoma
       - Systemic EBV positive T-cell lymphoproliferative disease of childhood
       - Systemic light chain disease
       - Systemic mastocytosis with AHNMD
@@ -3728,13 +3742,13 @@ properties:
       - T-gamma lymphoproliferative disease
       - T-zone lymphoma
       - T/NK-cell lymphoma
-      - Tanycytic ependymoma 
-      - Telangiectatic osteosarcoma 
-      - Tenosynovial giant cell tumor 
+      - Tanycytic ependymoma
+      - Telangiectatic osteosarcoma
+      - Tenosynovial giant cell tumor
       - Teratoblastoma, malignant
       - Teratocarcinoma
       - Teratoid medulloepithelioma
-      - Teratoid medulloepithelioma, benign 
+      - Teratoid medulloepithelioma, benign
       - Teratoma with malignant transformation
       - Teratoma, benign
       - Teratoma, differentiated
@@ -3742,12 +3756,12 @@ properties:
       - Teratoma, NOS
       - Terminal duct adenocarcinoma
       - Testicular adenoma
-      - Testicular stromal tumor 
-      - Theca cell tumor 
-      - Theca cell-granulosa cell tumor 
-      - Thecoma, luteinized 
-      - Thecoma, malignant 
-      - Thecoma, NOS 
+      - Testicular stromal tumor
+      - Theca cell tumor
+      - Theca cell-granulosa cell tumor
+      - Thecoma, luteinized
+      - Thecoma, malignant
+      - Thecoma, NOS
       - Therapy related myeloid neoplasm
       - Therapy-related acute myeloid leukemia, alkylating agent related
       - Therapy-related acute myeloid leukemia, epipodophyllotoxin-related
@@ -3755,43 +3769,43 @@ properties:
       - Therapy-related myelodysplastic syndrome, alkylating agent related
       - Therapy-related myelodysplastic syndrome, epipodophyllotoxin-related
       - Therapy-related myelodysplastic syndrome, NOS
-      - Thymic carcinoma, NOS 
-      - Thymic large B-cell lymphoma 
-      - Thymoma, atypical, malignant 
-      - Thymoma, atypical, NOS 
-      - Thymoma, benign 
-      - Thymoma, cortical, malignant 
-      - Thymoma, cortical, NOS 
-      - Thymoma, epithelial, malignant 
-      - Thymoma, epithelial, NOS 
-      - Thymoma, lymphocyte-rich, malignant 
-      - Thymoma, lymphocyte-rich, NOS 
-      - Thymoma, lymphocytic, malignant 
-      - Thymoma, lymphocytic, NOS 
-      - Thymoma, malignant, NOS 
-      - Thymoma, medullary, malignant 
-      - Thymoma, medullary, NOS 
-      - Thymoma, mixed type, malignant 
-      - Thymoma, mixed type, NOS 
-      - Thymoma, NOS 
-      - Thymoma, organoid, malignant 
-      - Thymoma, organoid, NOS 
-      - Thymoma, predominantly cortical, malignant 
-      - Thymoma, predominantly cortical, NOS 
-      - Thymoma, spindle cell, malignant 
-      - Thymoma, spindle cell, NOS 
-      - Thymoma, type A, malignant 
-      - Thymoma, type A, NOS 
-      - Thymoma, type AB, malignant 
-      - Thymoma, type AB, NOS 
-      - Thymoma, type B1, malignant 
-      - Thymoma, type B1, NOS 
-      - Thymoma, type B2, malignant 
-      - Thymoma, type B2, NOS 
-      - Thymoma, type B3, malignant 
-      - Thymoma, type B3, NOS 
-      - Thymoma, type C 
-      - Tibial adamantinoma 
+      - Thymic carcinoma, NOS
+      - Thymic large B-cell lymphoma
+      - Thymoma, atypical, malignant
+      - Thymoma, atypical, NOS
+      - Thymoma, benign
+      - Thymoma, cortical, malignant
+      - Thymoma, cortical, NOS
+      - Thymoma, epithelial, malignant
+      - Thymoma, epithelial, NOS
+      - Thymoma, lymphocyte-rich, malignant
+      - Thymoma, lymphocyte-rich, NOS
+      - Thymoma, lymphocytic, malignant
+      - Thymoma, lymphocytic, NOS
+      - Thymoma, malignant, NOS
+      - Thymoma, medullary, malignant
+      - Thymoma, medullary, NOS
+      - Thymoma, mixed type, malignant
+      - Thymoma, mixed type, NOS
+      - Thymoma, NOS
+      - Thymoma, organoid, malignant
+      - Thymoma, organoid, NOS
+      - Thymoma, predominantly cortical, malignant
+      - Thymoma, predominantly cortical, NOS
+      - Thymoma, spindle cell, malignant
+      - Thymoma, spindle cell, NOS
+      - Thymoma, type A, malignant
+      - Thymoma, type A, NOS
+      - Thymoma, type AB, malignant
+      - Thymoma, type AB, NOS
+      - Thymoma, type B1, malignant
+      - Thymoma, type B1, NOS
+      - Thymoma, type B2, malignant
+      - Thymoma, type B2, NOS
+      - Thymoma, type B3, malignant
+      - Thymoma, type B3, NOS
+      - Thymoma, type C
+      - Tibial adamantinoma
       - Trabecular adenocarcinoma
       - Trabecular adenoma
       - Trabecular carcinoma
@@ -3801,7 +3815,7 @@ properties:
       - Transitional carcinoma
       - Transitional cell carcinoma
       - Transitional cell carcinoma in situ
-      - Transitional cell carcinoma, micropapillary 
+      - Transitional cell carcinoma, micropapillary
       - Transitional cell carcinoma, sarcomatoid
       - Transitional cell carcinoma, spindle cell
       - Transitional cell papilloma, benign
@@ -3812,19 +3826,19 @@ properties:
       - Transitional papilloma
       - Transitional papilloma, inverted, benign
       - Transitional papilloma, inverted, NOS
-      - Transitional pineal tumor 
-      - Trichilemmal carcinoma 
-      - Trichilemmocarcinoma 
-      - Trichilemmoma 
-      - Trichodiscoma 
-      - Trichoepithelioma 
-      - Trichofolliculoma 
+      - Transitional pineal tumor
+      - Trichilemmal carcinoma
+      - Trichilemmocarcinoma
+      - Trichilemmoma
+      - Trichodiscoma
+      - Trichoepithelioma
+      - Trichofolliculoma
       - Triton tumor, malignant
       - Trophoblastic tumor, epithelioid
       - True histiocytic lymphoma
       - Tubular adenocarcinoma
       - Tubular adenoma, NOS
-      - Tubular androblastoma with lipid storage 
+      - Tubular androblastoma with lipid storage
       - Tubular androblastoma, NOS
       - Tubular carcinoid
       - Tubular carcinoma
@@ -3843,7 +3857,7 @@ properties:
       - Tumor, secondary
       - Tumorlet, benign
       - Tumorlet, NOS
-      - Turban tumor 
+      - Turban tumor
       - Typical carcinoid
       - Unclassified tumor, benign
       - Unclassified tumor, borderline malignancy
@@ -3856,8 +3870,8 @@ properties:
       - Urothelial carcinoma, NOS
       - Urothelial papilloma, NOS
       - Urticaria pigmentosa
-      - Vaginal intraepithelial neoplasia, grade III 
-      - VAIN III 
+      - Vaginal intraepithelial neoplasia, grade III
+      - VAIN III
       - Vascular leiomyoma
       - Venous hemangioma
       - Verrucous carcinoma, NOS
@@ -3869,21 +3883,21 @@ properties:
       - Villous adenocarcinoma
       - Villous adenoma, NOS
       - Villous papilloma
-      - VIN III 
+      - VIN III
       - Vipoma, malignant
       - Vipoma, NOS
       - Von Recklinghausen disease (except of bone)
-      - Vulvar intraepithelial neoplasia, grade III 
-      - Waldenstrom macroglobulinemia 
-      - Warthin tumor 
+      - Vulvar intraepithelial neoplasia, grade III
+      - Waldenstrom macroglobulinemia
+      - Warthin tumor
       - Warty carcinoma
-      - Water-clear cell adenocarcinoma 
-      - Water-clear cell adenoma 
-      - Water-clear cell carcinoma 
+      - Water-clear cell adenocarcinoma
+      - Water-clear cell adenoma
+      - Water-clear cell carcinoma
       - Well differentiated liposarcoma of superficial soft tissue
       - Well differentiated papillary mesothelioma, benign
-      - Well differentiated thymic carcinoma 
-      - Wilms tumor 
+      - Well differentiated thymic carcinoma
+      - Wilms tumor
       - Wolffian duct adenoma
       - Wolffian duct carcinoma
       - Wolffian duct tumor

--- a/gdcdictionary/schemas/family_history.yaml
+++ b/gdcdictionary/schemas/family_history.yaml
@@ -77,7 +77,16 @@ properties:
   relationship_age_at_diagnosis:
     term:
       $ref: "_terms.yaml#/relationship_age_at_diagnosis"
-    type: number
+    type: integer
+    maximum: 89
+    minimum: 0
+
+  relationship_age_at_diagnosis_gt89:
+    term:
+      $ref: "_terms.yaml#/relationship_age_at_diagnosis_gt89"
+    enum:
+      - "Yes"
+      - "No"
 
   relationship_primary_diagnosis:
     term:

--- a/gdcdictionary/schemas/sequencing_assay.yaml
+++ b/gdcdictionary/schemas/sequencing_assay.yaml
@@ -8,7 +8,7 @@ category: notation
 program: '*'
 project: '*'
 description: >
-  Information pertaining to processed results obtained from a sequencing assay. 
+  Information pertaining to processed results obtained from a sequencing assay.
 additionalProperties: false
 submittable: true
 validators: null
@@ -26,7 +26,7 @@ links:
     label: data_from
     target_type: read_group
     multiplicity: many_to_many
-    required: false
+    required: true
 
 required:
   - submitter_id
@@ -43,7 +43,7 @@ properties:
     description: "General name or description of the method used to characterize the analyte."
     enum:
       - Targeted Sequencing
-      - Copy Number Analysis 
+      - Copy Number Analysis
   assay_target:
     description: "Gene of interest for the assay."
     type: string


### PR DESCRIPTION
To help prevent the accidental submission of PHI to the BloodPAC data commons, restrictions are added for "age_at_" and "days_to_" properties.
Specifically, ages in days (or days_to_birth) are restricted to "maximum: 32872" and ages in years to "maximum: 89".
