### PR TITLE
added link from analyte to biospecimen

### DIFF
--- a/gdcdictionary/schemas/analyte.yaml
+++ b/gdcdictionary/schemas/analyte.yaml
@@ -44,6 +44,12 @@ links:
         target_type: study
         multiplicity: many_to_many
         required: false
+      - name: biospecimens
+        backref: analytes
+        label: derived_from
+        target_type: biospecimen
+        multiplicity: many_to_many
+        required: true
 
 uniqueKeys:
   - [id]
@@ -143,4 +149,6 @@ properties:
   aliquots:
     $ref: "_definitions.yaml#/to_many"
   studies:
+    $ref: "_definitions.yaml#/to_many"
+  biospecimens:
     $ref: "_definitions.yaml#/to_many"


### PR DESCRIPTION
[OCC-965](https://occ-data.atlassian.net/browse/OCC-965)

created a link/key from analyte to bio specimen as the analytical sites combine the aliquots to generate one result on the bio specimen level.