### PR TITLE
MTDE DD changes v1

### DIFF
--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -794,13 +794,11 @@ freezing_method:
     cde_version: 1.0
     term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432607&version=1.0"
 
-gender:
+sex:
   description: >
-    Text designations that identify gender. Gender is described as the assemblage of properties that
-    distinguish people on the basis of their societal roles. [Explanatory Comment 1: Identification
-    of gender is based upon self-report and may come from a form, questionnaire, interview, etc.]
+    The sex or gender of the participant assigned at birth
   termDef:
-    term: Person Gender Text Type
+    term: Person Sex Text Type
     source: caDSR
     cde_id: 2200604
     cde_version: 3.0

--- a/gdcdictionary/schemas/_terms.yaml
+++ b/gdcdictionary/schemas/_terms.yaml
@@ -1748,17 +1748,6 @@ treatment_type:
     cde_version: 1.0
     term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5102381&version=1.0"
 
-tumor_grade:
-  description: >
-    Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation
-    and aggressiveness.
-  termDef:
-    term: Neoplasm Histologic Grade
-    source: caDSR
-    cde_id: 2785839
-    cde_version: 2.0
-    term_url: "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2785839&version=2.0"
-
 tumor_code: # TOREVIEW
   description: >
     A specification of a cancer through cellular origin and localization.

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -70,27 +70,32 @@ properties:
     description: >
       The number of days between the date used for index and the date the patient was lost to follow-up.
     type: integer
-
-  promtheus_id:
+  
+  days_to_sample_collection:
     description: >
-      Id for promethus record
+      The number of days Duration from Sample Collection
+    type: integer
+
+  prometheus_id:
+    description: >
+      Id for prometheus record
     type: string
 
   apollo_id:
     description: >
-      Apollo id for promethus record
+      Apollo id for prometheus record
     type: string
 
   metabolomic_data_available:
     description: >
-      Apollo id for promethus record
+      A yes/no indicator related to whether metabolomic data is available for the patient
     enum:
       - "Yes"
       - "No"
 
   exposure_data_available:
     description: >
-      Apollo id for promethus record
+      A yes/no indicator related to whether exposure data is available for the patient
     enum:
       - "Yes"
       - "No"

--- a/gdcdictionary/schemas/case.yaml
+++ b/gdcdictionary/schemas/case.yaml
@@ -48,10 +48,10 @@ properties:
       the patient. Work with your collaborators to decide on the patient's id.
     type: string
 
-  index_date:
+  index_event:
     description: >
-      The reference or anchor date used during date obfuscation, where a single date is obscured by
-      creating one or more date ranges in relation to this date.
+      Specifies the clinical or study-related event that serves as the anchor date for date
+      obfuscation. All derived or shifted dates are calculated relative to the selected event.
     enum:
       - Diagnosis
       - First Patient Visit

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -100,7 +100,7 @@ properties:
 
   self_identified_sex:
     description: >
-      The sex or sex assignment preferred by the participant.
+      The sex or gender assignment preferred by the participant.
     enum:
       - "Female"
       - "Female-to-Male Transsexual"

--- a/gdcdictionary/schemas/demographic.yaml
+++ b/gdcdictionary/schemas/demographic.yaml
@@ -76,9 +76,9 @@ properties:
       - "Not Hispanic or Latino"
       - "Unknown"
 
-  gender:
+  sex:
     term:
-      $ref: "_terms.yaml#/gender"
+      $ref: "_terms.yaml#/sex"
     enum:
       - "Female"
       - "Male"
@@ -98,9 +98,9 @@ properties:
       - "Other"
       - "Unknown"
 
-  self_identified_gender:
+  self_identified_sex:
     description: >
-      The sex or gender assignment preferred by the participant.
+      The sex or sex assignment preferred by the participant.
     enum:
       - "Female"
       - "Female-to-Male Transsexual"

--- a/gdcdictionary/schemas/diagnosis.yaml
+++ b/gdcdictionary/schemas/diagnosis.yaml
@@ -37,7 +37,7 @@ required:
   - morphology
   - primary_diagnosis
   - tissue_or_organ_of_origin
-  - tumor_grade
+  - cancer_grade
 
 
 uniqueKeys:
@@ -3949,16 +3949,6 @@ properties:
       $ref: "_terms.yaml#/tissue_or_organ_of_origin"
     type: string
 
-  tumor_grade:
-    term:
-      $ref: "_terms.yaml#/tumor_grade"
-    enum:
-      - "GX Grade cannot be assessed (undetermined grade)"
-      - "G1 Well differentiated (low grade)"
-      - "G2 Moderately differentiated (intermediate grade)"
-      - "G3 Poorly differentiated (high grade)"
-      - "G4 Undifferentiated (high grade)"
-      - "Unknown"
 
   # Fields for prometheus-3a
   days_to_metastatic_diagnosis:
@@ -3986,7 +3976,7 @@ properties:
     type: string
 
   cancer_grade:
-    description: "Associated cancer grade (e.g. 0, 1, 2, 3, 4)."
+    description: "Associated cancer grade (e.g. 0, 1, 2, 3, 4). The values represents, Grade 0 - Grade cannot be assessed (undetermined grade), Grade 1 - Well differentiated (low grade), Grade 2 - Moderately differentiated (intermediate grade), Grade 3 - Poorly differentiated (high grade), Grade 4 - Undifferentiated (high grade)"
     enum:
       - Grade 0
       - Grade 1

--- a/gdcdictionary/schemas/exposure.yaml
+++ b/gdcdictionary/schemas/exposure.yaml
@@ -76,14 +76,14 @@ properties:
     term:
       $ref: "_terms.yaml#/tobacco_smoking_status"
     enum:
-      - "1"
-      - "2"
-      - "3"
-      - "4"
-      - "5"
-      - "6"
-      - "7"
-      - Unknown
+      - "Lifelong Non-Smoker"
+      - "Current Smoker"
+      - "Current Reformed Smoker, Duration Not Specified"
+      - "Current Reformed Smoker for ≤ 15 years"
+      - "Current Reformed Smoker for > 15 years"
+      - "Smoker at Diagnosis"
+      - "Smoking History Not Documented"
+      - "Unknown"
   years_smoked:
     term:
       $ref: "_terms.yaml#/years_smoked"

--- a/gdcdictionary/schemas/family_history.yaml
+++ b/gdcdictionary/schemas/family_history.yaml
@@ -54,9 +54,9 @@ properties:
       $ref: "_terms.yaml#/relationship_type"
     type: string
 
-  relationship_gender:
+  relationship_sex:
     term:
-      $ref: "_terms.yaml#/gender"
+      $ref: "_terms.yaml#/sex"
     enum:
       - female
       - male

--- a/gdcdictionary/schemas/treatment.yaml
+++ b/gdcdictionary/schemas/treatment.yaml
@@ -216,7 +216,7 @@ properties:
     description: "The total number of unique systemic medical interventions, including the current intervention, in treating metastatic disease."
     type: integer
 
-  complete_resection_no_clear_margins:
+  complete_resection_clear_margins:
     description: "Was there a complete surgical resection with clear margins?"
     enum:
       - "Yes"

--- a/sandbox/case/__schema.yaml
+++ b/sandbox/case/__schema.yaml
@@ -45,10 +45,10 @@ schema:
       constraints:
         unique: false  # local overriding for uniqueness
     -
-      name: gender
+      name: sex
       type: string
-      title: Gender  # use title for nice display label
-      description: "Identification of gender is based upon self-report and may come from a form, questionnaire, interview, etc"
+      title: Sex  # use title for nice display label
+      description: "Identification of sex is based upon self-report and may come from a form, questionnaire, interview, etc"
       cde_id: 2200604
       search: terms_facet
       constraints:

--- a/sandbox/case/__schema.yaml
+++ b/sandbox/case/__schema.yaml
@@ -48,7 +48,7 @@ schema:
       name: sex
       type: string
       title: Sex  # use title for nice display label
-      description: "Identification of sex is based upon self-report and may come from a form, questionnaire, interview, etc"
+      description: "The sex or gender of the participant assigned at birth"
       cde_id: 2200604
       search: terms_facet
       constraints:

--- a/sandbox/diagnosis/__schema.yaml
+++ b/sandbox/diagnosis/__schema.yaml
@@ -133,14 +133,6 @@ schema:
           - Nottingham grading system
           - Glioblastoma pathology nuclear grade
     -
-      name: tumor_grade  # don't we need this?
-      title: Tumor grade
-      description: "Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness."
-      type: string
-      constraints:
-        required: false
-        allowed: [ GX, G1, G2, G3, G4 ]
-    -
       name: vital_status  # do we need this?
       title: Vital status
       description: Indicate whether the patient was living or deceased at the date of last contact

--- a/sandbox/family_history/__schema.yaml
+++ b/sandbox/family_history/__schema.yaml
@@ -46,8 +46,8 @@ schema:
         required: false
         unique: false
         allowed: [ parent, sibling, offspring, grandparent ]
-    - name: relationship_gender
-      description: "Provide the patient's relationship gender using the defined categories."
+    - name: relationship_sex
+      description: "Provide the patient's relationship sex or gender assigned at birth using the defined categories."
       type: string
       constraints:
         required: false


### PR DESCRIPTION
- Renamed the field to `treatment.complete_resection_clear_margins`
- Removed `tumor_grade` and moved its values and description into the `cancer_grade` description
- Added `case.days_to_sample_collection`.
- Renamed `index_date` to `index_event`
- Updated `tobacco exposure` values to use clear string values instead of numeric ranges (1–7)
- Changed `gender` to `sex`.
- Fixed some descriptions and spelling mistakes (Prometheus)